### PR TITLE
Support the Prompt Builder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (1.5.0)
+    omniai-google (1.6.0)
       event_stream_parser
       omniai
       zeitwerk
@@ -50,7 +50,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    omniai (1.5.1)
+    omniai (1.6.0)
       event_stream_parser
       http
       zeitwerk
@@ -63,7 +63,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -23,6 +23,46 @@ module OmniAI
         GEMINI_FLASH = GEMINI_1_5_FLASH
       end
 
+      TEXT_SERIALIZER = lambda do |content, *|
+        { text: content.text }
+      end
+
+      # @param [Message]
+      # @return [Hash]
+      # @example
+      #   message = Message.new(...)
+      #   MESSAGE_SERIALIZER.call(message)
+      MESSAGE_SERIALIZER = lambda do |message, context:|
+        parts = message.content.is_a?(String) ? [Text.new(message.content)] : message.content
+
+        {
+          role: message.role,
+          parts: parts.map { |part| part.serialize(context:) },
+        }
+      end
+
+      # @param [Media]
+      # @return [Hash]
+      # @example
+      #   media = Media.new(...)
+      #   MEDIA_SERIALIZER.call(media)
+      MEDIA_SERIALIZER = lambda do |media, *|
+        {
+          inlineData: {
+            mimeType: media.type,
+            data: media.data,
+          },
+        }
+      end
+
+      # @return [Context]
+      CONTEXT = Context.build do |context|
+        context.serializers[:message] = MESSAGE_SERIALIZER
+        context.serializers[:text] = TEXT_SERIALIZER
+        context.serializers[:file] = MEDIA_SERIALIZER
+        context.serializers[:url] = MEDIA_SERIALIZER
+      end
+
       protected
 
       # @return [HTTP::Response]
@@ -67,9 +107,7 @@ module OmniAI
       #
       # @return [Array<Hash>]
       def contents
-        messages.map do |message|
-          { role: message[:role], parts: [{ text: message[:content] }] }
-        end
+        @prompt.serialize(context: CONTEXT)
       end
 
       # @return [String]

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
   end
 end

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe OmniAI::Google::Chat do
 
     context 'with an array prompt' do
       let(:prompt) do
-        [
-          { role: OmniAI::Chat::Role::SYSTEM, content: 'You are a helpful assistant.' },
-          { role: OmniAI::Chat::Role::USER, content: 'What is the capital of Canada?' },
-        ]
+        OmniAI::Chat::Prompt.build do |prompt|
+          prompt.system('You are a helpful assistant.')
+          prompt.user('What is the capital of Canada?')
+        end
       end
 
       before do
@@ -119,6 +119,52 @@ RSpec.describe OmniAI::Google::Chat do
         completion
         expect(chunks.map { |chunk| chunk.choice.delta.content }).to eql(%w[A B])
       end
+    end
+
+    context 'when using files / URLs' do
+      let(:io) { Tempfile.new }
+
+      let(:prompt) do
+        OmniAI::Chat::Prompt.build do |prompt|
+          prompt.user do |message|
+            message.text('What are these photos of?')
+            message.url('https://localhost/cat.jpg', 'image/jpeg')
+            message.url('https://localhost/dog.jpg', 'image/jpeg')
+            message.file(io, 'image/jpeg')
+          end
+        end
+      end
+
+      before do
+        stub_request(:get, 'https://localhost/cat.jpg').to_return(body: 'cat')
+        stub_request(:get, 'https://localhost/dog.jpg').to_return(body: 'dog')
+        stub_request(:post, "https://generativelanguage.googleapis.com/v1/models/#{model}:generateContent?key=...")
+          .with(body: {
+            contents: [
+              {
+                role: 'user',
+                parts: [
+                  { text: 'What are these photos of?' },
+                  { inlineData: { mimeType: 'image/jpeg', data: 'Y2F0' } },
+                  { inlineData: { mimeType: 'image/jpeg', data: 'ZG9n' } },
+                  { inlineData: { mimeType: 'image/jpeg', data: '' } },
+                ],
+              },
+            ],
+          })
+          .to_return_json(body: {
+            candidates: [{
+              index: 0,
+              content: {
+                role: 'assistant',
+                parts: [{ text: 'They are a photo of a cat and a photo of a dog.' }],
+              },
+            }],
+          })
+      end
+
+      it { expect(completion.choice.message.role).to eql('assistant') }
+      it { expect(completion.choice.message.content).to eql('They are a photo of a cat and a photo of a dog.') }
     end
   end
 end


### PR DESCRIPTION
Compatibility with features like tools and files / URLs introduces a number of complexities when not using a standardized API for prompts. This swaps to use a better API when building prompts

## Usage

**w/ a basic prompt**

```ruby
completion = client.chat('What is the capital of Japan?')
```

**w/ a complex prompt**

```ruby
completion = client.chat do |prompt|
  prompt.system 'You are a helpful assistant with an expertise in animals.'
  prompt.user do |message|
    message.text 'What animals are in the attached photos?'
    message.url('https://.../cat.jpeg', "image/jpeg")
    message.url('https://.../dog.jpeg', "image/jpeg")
    message.file('./hamster.jpeg', "image/jpeg")
  end
end
```