### PR TITLE
Fix for Gemini Not Supporting ‘system’ role

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (1.6.2)
+    omniai-google (1.6.3)
       event_stream_parser
       omniai
       zeitwerk

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -36,9 +36,10 @@ module OmniAI
       #   MESSAGE_SERIALIZER.call(message)
       MESSAGE_SERIALIZER = lambda do |message, context:|
         parts = message.content.is_a?(String) ? [Text.new(message.content)] : message.content
+        role = message.system? ? Role::USER : message.role
 
         {
-          role: message.role,
+          role:,
           parts: parts.map { |part| part.serialize(context:) },
         }
       end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = '1.6.2'
+    VERSION = '1.6.3'
   end
 end

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OmniAI::Google::Chat do
         stub_request(:post, "https://generativelanguage.googleapis.com/v1/models/#{model}:generateContent?key=...")
           .with(body: {
             contents: [
-              { role: 'system', parts: [{ text: 'You are a helpful assistant.' }] },
+              { role: 'user', parts: [{ text: 'You are a helpful assistant.' }] },
               { role: 'user', parts: [{ text: 'What is the capital of Canada?' }] },
 
             ],


### PR DESCRIPTION
Gemini requires everything be submitted as a user.