### PR TITLE
Support for Embeddings APIs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (1.9.2)
+    omniai-google (1.9.3)
       event_stream_parser
       omniai
       zeitwerk
@@ -35,7 +35,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    hashdiff (1.1.1)
+    hashdiff (1.1.2)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -45,7 +45,7 @@ GEM
     http-cookie (1.0.7)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    json (2.7.5)
+    json (2.8.1)
     language_server-protocol (3.17.0.3)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
@@ -56,7 +56,7 @@ GEM
       http
       zeitwerk
     parallel (1.26.3)
-    parser (3.3.5.1)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     public_suffix (6.0.1)
@@ -90,7 +90,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.33.0)
+    rubocop-ast (1.35.0)
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -120,3 +120,12 @@ end
 ```
 
 [Google API Reference `stream`](https://ai.google.dev/gemini-api/docs/api-overview#stream)
+
+### Embed
+
+Text can be converted into a vector embedding for similarity comparison usage via:
+
+```ruby
+response = client.embed('The quick brown fox jumps over a lazy dog.')
+response.embedding # [0.0, ...]
+```

--- a/examples/embed
+++ b/examples/embed
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'omniai/google'
+
+CLIENT = OmniAI::Google::Client.new
+
+Entry = Data.define(:text, :embedding) do
+  def initialize(text:)
+    super(text:, embedding: CLIENT.embed(text).embedding)
+  end
+end
+
+ENTRIES = [
+  Entry.new(text: 'John is a musician.'),
+  Entry.new(text: 'Paul is a plumber.'),
+  Entry.new(text: 'George is a teacher.'),
+  Entry.new(text: 'Ringo is a doctor.'),
+].freeze
+
+def search(query)
+  embedding = CLIENT.embed(query).embedding
+
+  results = ENTRIES.sort_by do |data|
+    Math.sqrt(data.embedding.zip(embedding).map { |a, b| (a - b)**2 }.reduce(:+))
+  end
+
+  puts "'#{query}': '#{results.first.text}'"
+end
+
+search('What does George do?')
+search('Who is a doctor?')
+search('Who do you call to fix a toilet?')

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -68,6 +68,23 @@ module OmniAI
       def upload(io)
         Upload.process!(client: self, io:)
       end
+
+      # @raise [OmniAI::Error]
+      #
+      # @param input [String, Array<String>, Array<Integer>] required
+      # @param model [String] optional
+      def embed(input, model: Embed::DEFAULT_MODEL)
+        Embed.process!(input, model:, client: self)
+      end
+
+      # @return [String]
+      def path
+        if @project_id
+          "/#{@version}/projects/#{@project_id}/locations/#{@location}/publishers/google"
+        else
+          "/#{@version}"
+        end
+      end
     end
   end
 end

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Google
+    # An Google embed implementation.
+    #
+    # Usage:
+    #
+    #   input = "..."
+    #   response = OmniAI::Google::Embed.process!(input, client: client)
+    #   response.embedding [0.0, ...]
+    class Embed < OmniAI::Embed
+      module Model
+        TEXT_EMBEDDING_004 = 'text-embedding-004'
+        TEXT_MULTILINGUAL_EMBEDDING_002 = 'text-multilingual-embedding-002'
+        EMBEDDING = TEXT_EMBEDDING_004
+        MULTILINGUAL_EMBEDDING = TEXT_MULTILINGUAL_EMBEDDING_002
+      end
+
+      DEFAULT_MODEL = Model::EMBEDDING
+
+      EMBEDDINGS_DESERIALIZER = proc do |data, *|
+        data['embeddings'].map { |embedding| embedding['values'] }
+      end
+
+      # @return [Context]
+      CONTEXT = Context.build do |context|
+        context.deserializers[:embeddings] = EMBEDDINGS_DESERIALIZER
+      end
+
+      protected
+
+      # @param response [HTTP::Response]
+      # @return [Response]
+      def parse!(response:)
+        Response.new(data: response.parse, context: CONTEXT)
+      end
+
+      # @return [Array<Hash<{ text: String }>]
+      def requests
+        arrayify(@input).map do |text|
+          {
+            model: "models/#{@model}",
+            content: { parts: [{ text: text }] },
+          }
+        end
+      end
+
+      # @return [Hash]
+      def payload
+        { requests: }
+      end
+
+      # @return [String]
+      def path
+        "/#{@client.path}/models/#{@model}:batchEmbedContents?key=#{@client.api_key}"
+      end
+
+      def arrayify(input)
+        input.is_a?(Array) ? input : [input]
+      end
+    end
+  end
+end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = '1.9.2'
+    VERSION = '1.9.3'
   end
 end

--- a/spec/omniai/google/client_spec.rb
+++ b/spec/omniai/google/client_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe OmniAI::Google::Client do
     end
   end
 
+  describe '#embed' do
+    it 'proxies' do
+      allow(OmniAI::Google::Embed).to receive(:process!)
+      client.embed('Hello!')
+      expect(OmniAI::Google::Embed).to have_received(:process!)
+    end
+  end
+
   describe '#upload' do
     let(:io) { StringIO.new('Hello!') }
 

--- a/spec/omniai/google/embed_spec.rb
+++ b/spec/omniai/google/embed_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::Google::Embed do
+  let(:client) { OmniAI::Google::Client.new }
+  let(:project_id) { 'fake' }
+
+  describe '.process!' do
+    subject(:process!) { described_class.process!(text, client:, model:) }
+
+    let(:text) { 'The quick brown fox jumps over a lazy dog.' }
+    let(:model) { described_class::DEFAULT_MODEL }
+    let(:location) { OmniAI::Google::Config::DEFAULT_LOCATION }
+
+    before do
+      stub_request(:post, 'https://generativelanguage.googleapis.com//v1beta/models/text-embedding-004:batchEmbedContents?key=...')
+        .with(body: {
+          requests: [
+            {
+              model: "models/#{model}",
+              content: { parts: [{ text: }] },
+            },
+          ],
+        })
+        .to_return_json(body: { embeddings: [{ values: [0.0] }] })
+    end
+
+    it { expect(process!).to be_a(OmniAI::Embed::Response) }
+    it { expect(process!.embedding).to eql([0.0]) }
+  end
+end


### PR DESCRIPTION
This supports generating embeddings using Google's APIs:

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require 'bundler/setup'
require 'omniai/google'

CLIENT = OmniAI::Google::Client.new

Entry = Data.define(:text, :embedding) do
  def initialize(text:)
    super(text:, embedding: CLIENT.embed(text).embedding)
  end
end

ENTRIES = [
  Entry.new(text: 'John is a musician.'),
  Entry.new(text: 'Paul is a plumber.'),
  Entry.new(text: 'George is a teacher.'),
  Entry.new(text: 'Ringo is a doctor.'),
].freeze

def search(query)
  embedding = CLIENT.embed(query).embedding

  results = ENTRIES.sort_by do |data|
    Math.sqrt(data.embedding.zip(embedding).map { |a, b| (a - b)**2 }.reduce(:+))
  end

  puts "'#{query}': '#{results.first.text}'"
end

search('What does George do?')
search('Who is a doctor?')
search('Who do you call to fix a toilet?')
```