### PR TITLE
Swap to Build Matrix on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,13 @@ orbs:
 
 executors:
   default:
+    parameters:
+      ruby-version:
+        description: "ruby version tag"
+        default: "3.4.1"
+        type: string
     docker:
-      - image: cimg/ruby:3.4.1
+      - image: cimg/ruby:<<parameters.ruby-version>>
 
 jobs:
   doc:
@@ -26,7 +31,13 @@ jobs:
       - ruby/install-deps
       - run: bundle exec yard doc
   rspec:
-    executor: default
+    parameters:
+      ruby-version:
+        description: "ruby version tag"
+        type: string
+    executor:
+      name: default
+      ruby-version: <<parameters.ruby-version>>
     steps:
       - checkout
       - ruby/install-deps
@@ -50,7 +61,13 @@ workflows:
   build:
     jobs:
       - doc
-      - rspec
+      - rspec:
+          matrix:
+            parameters:
+              ruby-version:
+                - "3.4.1"
+                - "3.3.7"
+                - "3.2.6"
       - rubocop
       - release:
           filters:


### PR DESCRIPTION
This ensures the project is build using the latest Ruby major / minor version for each supported.