### PR TITLE
Support for Gemini Flash 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "irb"
 gem "logger"
 gem "rake"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (1.9.5)
+    omniai-google (1.9.6)
       event_stream_parser
       omniai
       zeitwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    date (3.4.1)
     diff-lcs (1.5.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
@@ -45,6 +46,11 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
     llhttp-ffi (0.5.0)
@@ -60,11 +66,21 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.11.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -105,6 +121,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    stringio (3.1.2)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -129,6 +146,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  irb
   logger
   omniai-google!
   rake

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -16,9 +16,6 @@ module OmniAI
         GEMINI_1_0_PRO = "gemini-1.0-pro"
         GEMINI_1_5_PRO = "gemini-1.5-pro"
         GEMINI_1_5_FLASH = "gemini-1.5-flash"
-        GEMINI_1_0_PRO_LATEST = "gemini-1.0-pro-latest"
-        GEMINI_1_5_PRO_LATEST = "gemini-1.5-pro-latest"
-        GEMINI_1_5_FLASH_LATEST = "gemini-1.5-flash-latest"
         GEMINI_PRO = GEMINI_1_5_PRO
         GEMINI_FLASH = GEMINI_1_5_FLASH
       end

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -16,8 +16,9 @@ module OmniAI
         GEMINI_1_0_PRO = "gemini-1.0-pro"
         GEMINI_1_5_PRO = "gemini-1.5-pro"
         GEMINI_1_5_FLASH = "gemini-1.5-flash"
+        GEMINI_2_0_FLASH = "gemini-2.0-flash"
         GEMINI_PRO = GEMINI_1_5_PRO
-        GEMINI_FLASH = GEMINI_1_5_FLASH
+        GEMINI_FLASH = GEMINI_2_0_FLASH
       end
 
       DEFAULT_MODEL = Model::GEMINI_PRO

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "1.9.5"
+    VERSION = "1.9.6"
   end
 end


### PR DESCRIPTION
This introduces an constant for `OmniAI::Google::Chat::Models::GEMINI_2_0_FLASH`. It also swaps the alias  `OmniAI::Google::Chat::Models::GEMINI_FLASH` from 1.5 to 2.0.