### PR TITLE
Lock OmniAI to ~> v1.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-google (1.9.6)
+    omniai-google (1.9.7)
       event_stream_parser
-      omniai
+      omniai (~> 1.9)
       zeitwerk
 
 GEM

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "1.9.6"
+    VERSION = "1.9.7"
   end
 end

--- a/omniai-google.gemspec
+++ b/omniai-google.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai"
+  spec.add_dependency "omniai", "~> 1.9"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This ensures any future breaking changes (e.g. 1.9 -> 2.0) do not break clients / require clients be upgraded in parallel.