### PR TITLE
Bump Default Embed Model from 004 to 005

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   rubocop-basic: rubocop.yml
 
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.0.0)
+    omniai-google (2.0.1)
       event_stream_parser
       omniai (~> 2.0)
       zeitwerk

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -12,8 +12,9 @@ module OmniAI
     class Embed < OmniAI::Embed
       module Model
         TEXT_EMBEDDING_004 = "text-embedding-004"
+        TEXT_EMBEDDING_005 = "text-embedding-005"
         TEXT_MULTILINGUAL_EMBEDDING_002 = "text-multilingual-embedding-002"
-        EMBEDDING = TEXT_EMBEDDING_004
+        EMBEDDING = TEXT_EMBEDDING_005
         MULTILINGUAL_EMBEDDING = TEXT_MULTILINGUAL_EMBEDDING_002
       end
 

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/omniai/google/embed_spec.rb
+++ b/spec/omniai/google/embed_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OmniAI::Google::Embed do
     let(:location) { OmniAI::Google::Config::DEFAULT_LOCATION }
 
     before do
-      stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/text-embedding-004:batchEmbedContents?key=...")
+      stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/text-embedding-005:batchEmbedContents?key=...")
         .with(body: {
           requests: [
             {


### PR DESCRIPTION
Per Google:

> For English text, use `text-embedding-005`