### PR TITLE
Define Constant for `GEMINI_2_5_PRO`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.0.0)
+    omniai-google (2.0.1)
       event_stream_parser
       omniai (~> 2.0)
       zeitwerk

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -15,6 +15,7 @@ module OmniAI
       module Model
         GEMINI_1_0_PRO = "gemini-1.0-pro"
         GEMINI_1_5_PRO = "gemini-1.5-pro"
+        GEMINI_2_5_PRO = "gemini-2.5-pro-exp-03-25"
         GEMINI_1_5_FLASH = "gemini-1.5-flash"
         GEMINI_2_0_FLASH = "gemini-2.0-flash"
         GEMINI_PRO = GEMINI_1_5_PRO

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end


### PR DESCRIPTION
https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/

Note: this currently points to “gemini-2.5-pro-exp-03-25” since no stable tag exists.