### PR TITLE
Support for Vertex AI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ RSpec/SpecFilePathFormat:
   CustomTransform:
     OmniAI: omniai
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.2.0)
+    omniai-google (2.2.1)
       event_stream_parser
+      googleauth
       omniai (~> 2.2)
       zeitwerk
 
@@ -18,10 +19,16 @@ GEM
       bigdecimal
       rexml
     date (3.4.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     event_stream_parser (1.0.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     ffi (1.17.1)
     ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-aarch64-linux-musl)
@@ -36,6 +43,18 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    google-cloud-env (2.2.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-logging-utils (0.1.0)
+    googleauth (1.14.0)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     hashdiff (1.1.2)
     http (5.2.0)
       addressable (~> 2.8)
@@ -52,19 +71,25 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.10.2)
+    jwt (2.10.1)
+      base64
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     llhttp-ffi (0.5.1)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
+    multi_json (1.15.0)
+    net-http (0.6.0)
+      uri
     omniai (2.2.0)
       event_stream_parser
       http
       logger
       zeitwerk
+    os (1.1.4)
     parallel (1.26.3)
-    parser (3.3.7.3)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     pp (0.6.2)
@@ -78,7 +103,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.11.0)
+    rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)
@@ -88,7 +113,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -121,16 +146,22 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    stringio (3.1.2)
+    stringio (3.1.6)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/README.md
+++ b/README.md
@@ -27,20 +27,65 @@ client = OmniAI::Google::Client.new
 A client may also be passed the following options:
 
 - `api_key` (required - default is `ENV['GOOGLE_API_KEY']`)
+- `credentials` (optional)
 - `host` (optional)
 - `version` (optional - options are `v1` or `v1beta`)
 
 ### Configuration
 
-Global configuration is supported for the following options:
+Vertex AI and Google AI offer different options for interacting w/ Google's AI APIs. Checkout the [Vertex AI and Google AI differences](https://cloud.google.com/vertex-ai/generative-ai/docs/overview#how-gemini-vertex-different-gemini-aistudio) to determine which option best fits your requirements.
+
+#### Authentication
+
+**w/ `api_key`**
+
+The quickest way to authenticate (available if using Google AI) is by using an API key:
 
 ```ruby
 OmniAI::Google.configure do |config|
   config.api_key = 'sk-...' # default: ENV['GOOGLE_API_KEY']
-  config.host = '...' # default: 'https://generativelanguage.googleapis.com'
-  config.version = OmniAI::Google::Config::Version::BETA # either 'v1' or 'v1beta'
 end
 ```
+
+**w/ `credentials`**
+
+An alternative approach for authentication (required if using Vertex AI) is to use credentials directly:
+
+```ruby
+require 'googleauth'
+
+credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+  json_key_io: File.open('credentials.json'),
+  scope: 'https://www.googleapis.com/auth/cloud-platform'
+)
+
+OmniAI::Google.configure do |config|
+  config.credentials = credentials
+end
+```
+
+#### Host
+
+The host (defaults to `https://generativelanguage.googleapis.com`) may be changed (required if using Vertex AI) using:
+
+```ruby
+OmniAI::Google.configure do |config|
+  config.host = 'https://us-east4-aiplatform.googleapis.com' # see https://cloud.google.com/vertex-ai/docs/general/locations
+end
+```
+
+#### Version
+
+The version (defaults to `v1beta`) may be changed using:
+
+```ruby
+OmniAI::Google.configure do |config|
+  # ...
+  config.version = OmniAI::Google::Config::Version::STABLE # see https://ai.google.dev/gemini-api/docs/api-versions
+end
+```
+
+_The default API version is configured to **v1beta** instead of **v1** due to various missing features in **v1**._
 
 ### Chat
 

--- a/examples/chat_with_vision
+++ b/examples/chat_with_vision
@@ -2,18 +2,25 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "omniai/openai"
-
-CLIENT = OmniAI::OpenAI::Client.new
+require "omniai/google"
 
 CAT_URL = "https://images.unsplash.com/photo-1472491235688-bdc81a63246e?q=80&w=1024&h=1024&fit=crop&fm=jpg"
 DOG_URL = "https://images.unsplash.com/photo-1517849845537-4d257902454a?q=80&w=1024&h=1024&fit=crop&fm=jpg"
 
-CLIENT.chat(stream: $stdout) do |prompt|
-  prompt.system("You are a helpful biologist with an expertise in animals that responds with the latin names.")
-  prompt.user do |message|
-    message.text("What animals are in the attached photos?")
-    message.url(CAT_URL, "image/jpeg")
-    message.url(DOG_URL, "image/jpeg")
+begin
+  client = OmniAI::Google::Client.new
+  cat_upload = client.upload(CAT_URL)
+  dog_upload = client.upload(DOG_URL)
+
+  client.chat(stream: $stdout) do |prompt|
+    prompt.system("You are a helpful biologist with an expertise in animals that responds with the latin names.")
+    prompt.user do |message|
+      message.text "What are these photos of?"
+      message.url(cat_upload.uri, cat_upload.mime_type)
+      message.url(dog_upload.uri, dog_upload.mime_type)
+    end
   end
+ensure
+  cat_upload&.delete!
+  dog_upload&.delete!
 end

--- a/lib/omniai/google.rb
+++ b/lib/omniai/google.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "googleauth"
 require "event_stream_parser"
 require "omniai"
 require "zeitwerk"

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -117,7 +117,7 @@ module OmniAI
 
       # @return [String]
       def path
-        "/#{@client.version}/models/#{@model}:#{operation}"
+        "#{@client.path}/models/#{@model}:#{operation}"
       end
 
       # @return [String]

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -24,22 +24,27 @@ module OmniAI
       #   @return [String, nil]
       attr_accessor :version
 
-      # @param api_key [String] optional - defaults to `OmniAI::Google.config.api_key`
-      # @param host [String] optional - defaults to `OmniAI::Google.config.host`
-      # @param version [String] optional - defaults to `OmniAI::Google.config.version`
-      # @param logger [Logger] optional - defaults to `OmniAI::Google.config.logger`
-      # @param timeout [Integer] optional - defaults to `OmniAI::Google.config.timeout`
+      # @param api_key [String] default is `OmniAI::Google.config.api_key`
+      # @param credentials [Google::Auth::ServiceAccountCredentials] default is `OmniAI::Google.config.credentials`
+      # @param host [String] default is `OmniAI::Google.config.host`
+      # @param version [String] default is `OmniAI::Google.config.version`
+      # @param logger [Logger] default is `OmniAI::Google.config.logger`
+      # @param timeout [Integer] default is `OmniAI::Google.config.timeout`
       def initialize(
         api_key: OmniAI::Google.config.api_key,
+        credentials: OmniAI::Google.config.credentials,
         logger: OmniAI::Google.config.logger,
         host: OmniAI::Google.config.host,
         version: OmniAI::Google.config.version,
         timeout: OmniAI::Google.config.timeout
       )
-        raise(ArgumentError, %(ENV['GOOGLE_API_KEY'] must be defined or `api_key` must be passed)) if api_key.nil?
+        if api_key.nil? && credentials.nil?
+          raise(ArgumentError, "either an `api_key` or `credentials` must be provided")
+        end
 
         super(api_key:, host:, logger:, timeout:)
 
+        @credentials = credentials
         @version = version
       end
 
@@ -79,11 +84,44 @@ module OmniAI
 
       # @return [String]
       def path
-        if @project_id
-          "/#{@version}/projects/#{@project_id}/locations/#{@location}/publishers/google"
+        if project && location
+          "/#{@version}/projects/#{project}/locations/#{location}/publishers/google"
         else
           "/#{@version}"
         end
+      end
+
+      # @return [HTTP::Client]
+      def connection
+        http = super
+        http = http.auth(auth) if auth?
+        http
+      end
+
+    private
+
+      # @return [String, nil]
+      def location
+        @location ||= begin
+          match = @host.match(%r{//(?<location>[\w\-]+)-aiplatform\.googleapis\.com})
+          match[:location] if match
+        end
+      end
+
+      # @return [String, nil]
+      def project
+        @credentials&.project_id
+      end
+
+      # @return [Boolean]
+      def auth?
+        !@credentials.nil?
+      end
+
+      # @return [String] e.g. "Bearer ..."
+      def auth
+        @credentials.fetch_access_token!
+        "Bearer #{@credentials.access_token}"
       end
     end
   end

--- a/lib/omniai/google/config.rb
+++ b/lib/omniai/google/config.rb
@@ -16,19 +16,26 @@ module OmniAI
       #   @return [String, nil]
       attr_accessor :version
 
+      # @!attribute [rw] credentials
+      #   @return [String, nil]
+      attr_accessor :credentials
+
       # @param api_key [String, nil] optional - defaults to `ENV['GOOGLE_API_KEY']`
+      # @param credentials [Google::Auth::ServiceAccountCredentials, nil] optional
       # @param host [String, nil] optional - defaults to `ENV['GOOGLE_HOST'] w/ fallback to `DEFAULT_HOST`
       # @param version [String, nil] optional - defaults to `ENV['GOOGLE_VERSION'] w/ fallback to `DEFAULT_VERSION`
-      # @param logger [Logger, nil] optional - defaults to
+      # @param logger [Logger, nil] optional
       # @param timeout [Integer, Hash, nil] optional
       def initialize(
         api_key: ENV.fetch("GOOGLE_API_KEY", nil),
+        credentials: nil,
         host: ENV.fetch("GOOGLE_HOST", DEFAULT_HOST),
         version: ENV.fetch("GOOGLE_VERSION", DEFAULT_VERSION),
         logger: nil,
         timeout: nil
       )
         super(api_key:, host:, logger:, timeout:)
+        @credentials = credentials
         @version = version
       end
     end

--- a/lib/omniai/google/upload.rb
+++ b/lib/omniai/google/upload.rb
@@ -27,7 +27,9 @@ module OmniAI
           response = @client
             .connection
             .headers({ "X-Goog-Upload-Protocol" => "raw" })
-            .post("/upload/#{@client.version}/files?key=#{@client.api_key}", body: HTTP::FormData::File.new(io))
+            .post("/upload/#{@client.version}/files",
+              params: { key: @client.api_key }.compact,
+              body: HTTP::FormData::File.new(io))
         end
 
         raise OmniAI::HTTPError, response.flush unless response.status.ok?

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end

--- a/omniai-google.gemspec
+++ b/omniai-google.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
+  spec.add_dependency "googleauth"
   spec.add_dependency "omniai", "~> 2.2"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/google/client_spec.rb
+++ b/spec/omniai/google/client_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe OmniAI::Google::Client do
-  subject(:client) { described_class.new }
+  subject(:client) { described_class.new(**options) }
+
+  let(:options) { {} }
 
   describe "#chat" do
     it "proxies" do
@@ -29,7 +31,42 @@ RSpec.describe OmniAI::Google::Client do
     end
   end
 
+  describe "#path" do
+    context "without options" do
+      it "returns the path" do
+        expect(client.path).to eq("/#{client.version}")
+      end
+    end
+
+    context "with options" do
+      let(:options) { { credentials:, host: } }
+      let(:credentials) { instance_double(Google::Auth::ServiceAccountCredentials, project_id: "manhattan") }
+      let(:host) { "https://us-east4-aiplatform.googleapis.com" }
+
+      it "returns the path" do
+        expect(client.path).to eq("/#{client.version}/projects/manhattan/locations/us-east4/publishers/google")
+      end
+    end
+  end
+
   describe "#connection" do
-    it { expect(client.connection).to be_a(HTTP::Client) }
+    context "without options" do
+      it "returns an HTTP client" do
+        expect(client.connection).to be_a(HTTP::Client)
+      end
+    end
+
+    context "with options" do
+      let(:options) { { credentials: } }
+      let(:credentials) { instance_double(Google::Auth::ServiceAccountCredentials) }
+
+      it "returns an HTTP client" do
+        allow(credentials).to receive(:fetch_access_token!)
+        allow(credentials).to receive(:access_token) { SecureRandom.alphanumeric }
+        expect(client.connection).to be_a(HTTP::Client)
+        expect(credentials).to have_received(:fetch_access_token!)
+        expect(credentials).to have_received(:access_token)
+      end
+    end
   end
 end


### PR DESCRIPTION
This supports credentials (required for Vertex AI) using `googleauth` as well as a custom path for `chat` / `embed` when using the credentials (e.g. `/projects/:project/locations/:location/publishers/google`).