### PR TITLE
Return Embedding Usage w/ Vertex

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.3.1)
+    omniai-google (2.3.2)
       event_stream_parser
       googleauth
       omniai (~> 2.3)
@@ -82,7 +82,7 @@ GEM
     multi_json (1.15.0)
     net-http (0.6.0)
       uri
-    omniai (2.3.0)
+    omniai (2.3.1)
       event_stream_parser
       http
       logger

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -28,6 +28,12 @@ module OmniAI
         data["predictions"].map { |prediction| prediction["embeddings"]["values"] }
       end
 
+      VERTEX_USAGE_DESERIALIZER = proc do |data, *|
+        tokens = data["predictions"].map { |prediction| prediction["embeddings"]["statistics"]["token_count"] }.sum
+
+        Usage.new(prompt_tokens: tokens, total_tokens: tokens)
+      end
+
       # @return [Context]
       DEFAULT_CONTEXT = Context.build do |context|
         context.deserializers[:embeddings] = DEFAULT_EMBEDDINGS_DESERIALIZER
@@ -36,6 +42,7 @@ module OmniAI
       # @return [Context]
       VERTEX_CONTEXT = Context.build do |context|
         context.deserializers[:embeddings] = VERTEX_EMBEDDINGS_DESERIALIZER
+        context.deserializers[:usage] = VERTEX_USAGE_DESERIALIZER
       end
 
     protected
@@ -48,12 +55,6 @@ module OmniAI
       # @return [Context]
       def context
         vertex? ? VERTEX_CONTEXT : DEFAULT_CONTEXT
-      end
-
-      # @param response [HTTP::Response]
-      # @return [Response]
-      def parse!(response:)
-        Response.new(data: response.parse, context:)
       end
 
       # @return [Array[Hash]]

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
   end
 end


### PR DESCRIPTION
The Vertex 'predict' API supports usage. This defines a deserializer to fetch it.