### PR TITLE
Fix Streaming w/ Tool-Call with Multiple Part Messages (e.g. text + tool-call at the same time)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.6.2)
+    omniai-google (2.6.3)
       event_stream_parser
       googleauth
       omniai (~> 2.6)

--- a/lib/omniai/google/chat/stream.rb
+++ b/lib/omniai/google/chat/stream.rb
@@ -44,8 +44,8 @@ module OmniAI
             @data[key] = value unless key.eql?("candidates")
           end
 
-          data["candidates"].each_with_index do |candidate, index|
-            process_candidate!(candidate:, index:, &block)
+          data["candidates"].each do |candidate|
+            process_candidate!(candidate:, &block)
           end
         end
 
@@ -53,37 +53,39 @@ module OmniAI
         # @yieldparam delta [OmniAI::Chat::Delta]
         #
         # @param candidate [Hash]
-        # @param index [Integer]
-        def process_candidate!(candidate:, index:, &block)
-          parts = candidate["content"]["parts"]
-          return unless parts
-
-          parts.each do |part|
+        def process_candidate!(candidate:, &block)
+          candidate["content"]["parts"].each do |part|
             block&.call(OmniAI::Chat::Delta.new(text: part["text"])) if part["text"]
           end
 
-          merge_candidate!(candidate:, index:)
+          merge_candidate!(candidate:)
         end
 
         # @param candidate [Hash]
-        # @param index [Integer]
-        def merge_candidate!(candidate:, index:)
+        def merge_candidate!(candidate:)
+          index = candidate["index"]
+          raise candidate.inspect if index.nil?
+
           if @data["candidates"][index].nil?
             @data["candidates"][index] = candidate
           else
-            merge_parts!(content: @data["candidates"][index]["content"], parts: candidate["content"]["parts"])
+            merge_parts!(parts: candidate["content"]["parts"], candidate: @data["candidates"][index])
           end
         end
 
-        # @param content [Hash]
         # @param parts [Array<Hash>]
-        def merge_parts!(content:, parts:)
-          parts.each_with_index do |part, index|
-            if content["parts"][index].nil?
-              content["parts"][index] = part
-            else
-              content["parts"][index]["text"] += part["text"]
-            end
+        # @param candidate [Hash]
+        def merge_parts!(parts:, candidate:)
+          parts.each { |part| merge_part!(part:, candidate:) }
+        end
+
+        # @param part [Hash]
+        # @param into [Hash]
+        def merge_part!(part:, candidate:)
+          if candidate["content"]["parts"][-1]&.key?("text") && part["text"]
+            candidate["content"]["parts"][-1]["text"] += part["text"]
+          else
+            candidate["content"]["parts"] << part
           end
         end
       end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.6.2"
+    VERSION = "2.6.3"
   end
 end

--- a/spec/omniai/google/chat/stream_spec.rb
+++ b/spec/omniai/google/chat/stream_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe OmniAI::Google::Chat::Stream do
               {
                 content: {
                   role: "model",
-                  parts: [{
-                    text: "Hello",
-                  }],
+                  parts: [{ text: "Hello" }],
                 },
+                index: 0,
               },
             ],
           },
@@ -30,6 +29,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                   role: "model",
                   parts: [{ text: " " }],
                 },
+                index: 0,
               },
             ],
           },
@@ -40,6 +40,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                   role: "model",
                   parts: [{ text: "World" }],
                 },
+                index: 0,
               },
             ],
           },
@@ -58,6 +59,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                   },
                 ],
               },
+              "index" => 0,
             },
           ],
         })
@@ -65,7 +67,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
 
       it "yields multiple times" do
         stream!
-        expect(deltas.filter(&:text?).map(&:text)).to eql([
+        expect(deltas.map(&:text)).to eql([
           "Hello",
           " ",
           "World",
@@ -85,14 +87,39 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                     {
                       functionCall: { name: "weather", arguments: JSON.generate(location: "Madrid") },
                     },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [
                     {
                       functionCall: { name: "weather", arguments: JSON.generate(location: "London") },
                     },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [
                     {
                       functionCall: { name: "weather", arguments: JSON.generate(location: "Berlin") },
                     },
                   ],
                 },
+                index: 0,
               },
             ],
           },
@@ -126,6 +153,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                   },
                 ],
               },
+              "index" => 0,
             },
           ],
         })
@@ -134,6 +162,136 @@ RSpec.describe OmniAI::Google::Chat::Stream do
       it "does not yield" do
         stream!
         expect(deltas).to eql([])
+      end
+    end
+
+    context "when parsing text and tool call list chunks" do
+      let(:chunks) do
+        [
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [{ text: "Hello" }],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [{ text: " " }],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [{ text: "World" }],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [
+                    {
+                      functionCall: { name: "weather", arguments: JSON.generate(location: "Madrid") },
+                    },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [
+                    {
+                      functionCall: { name: "weather", arguments: JSON.generate(location: "London") },
+                    },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          },
+          {
+            candidates: [
+              {
+                content: {
+                  role: "model",
+                  parts: [
+                    {
+                      functionCall: { name: "weather", arguments: JSON.generate(location: "Berlin") },
+                    },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          },
+        ].map { |chunk| "data: #{JSON.generate(chunk)}\n\n" }
+      end
+
+      it "combines multiple chunks" do
+        expect(stream!).to eql({
+          "candidates" => [
+            {
+              "content" => {
+                "role" => "model",
+                "parts" => [
+                  {
+                    "text" => "Hello World",
+                  },
+                  {
+                    "functionCall" => {
+                      "name" => "weather",
+                      "arguments" => JSON.generate(location: "Madrid"),
+                    },
+                  },
+                  {
+                    "functionCall" => {
+                      "name" => "weather",
+                      "arguments" => JSON.generate(location: "London"),
+                    },
+                  },
+                  {
+                    "functionCall" => {
+                      "name" => "weather",
+                      "arguments" => JSON.generate(location: "Berlin"),
+                    },
+                  },
+                ],
+              },
+              "index" => 0,
+            },
+          ],
+        })
+      end
+
+      it "yields multiple times" do
+        stream!
+        expect(deltas.map(&:text)).to eql([
+          "Hello",
+          " ",
+          "World",
+        ])
       end
     end
   end

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -106,9 +106,9 @@ RSpec.describe OmniAI::Google::Chat do
             ],
           })
           .to_return(body: <<~STREAM)
-            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'Hello' }], role: 'model' } }])}\n
-            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: ' ' }], role: 'model' } }])}\n
-            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'World' }], role: 'model' } }])}\n
+            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'Hello' }], role: 'model' }, index: 0 }])}\n
+            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: ' ' }], role: 'model' }, index: 0 }])}\n
+            data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'World' }], role: 'model' }, index: 0 }])}\n
           STREAM
       end
 


### PR DESCRIPTION
This properly handles merging text / non-text parts following the pattern:

1. If the delta part is text and the latest part is text they are merged.
2. Otherwise the part is appended.