### PR TITLE
Bump Ruby from v3.4.2 to v3.4.4 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
     parameters:
       ruby-version:
         description: "ruby version tag"
-        default: "3.4.2"
+        default: "3.4.4"
         type: string
     docker:
       - image: cimg/ruby:<<parameters.ruby-version>>
@@ -71,7 +71,7 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "3.4.2"
+                - "3.4.4"
                 - "3.3.7"
                 - "3.2.7"
       - rubocop


### PR DESCRIPTION
This fixes a version mis-match introduced with transcribe.