### PR TITLE
Swap Model Tags to Non-Preview Versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (2.7.7)
+    omniai-google (2.7.8)
       event_stream_parser
       google-cloud-storage
       googleauth

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -15,10 +15,10 @@ module OmniAI
       module Model
         GEMINI_1_0_PRO = "gemini-1.0-pro"
         GEMINI_1_5_PRO = "gemini-1.5-pro"
-        GEMINI_2_5_PRO = "gemini-2.5-pro-preview-06-05"
+        GEMINI_2_5_PRO = "gemini-2.5-pro"
         GEMINI_1_5_FLASH = "gemini-1.5-flash"
         GEMINI_2_0_FLASH = "gemini-2.0-flash"
-        GEMINI_2_5_FLASH = "gemini-2.5-flash-preview-04-17"
+        GEMINI_2_5_FLASH = "gemini-2.5-flash"
         GEMINI_PRO = GEMINI_1_5_PRO
         GEMINI_FLASH = GEMINI_2_5_FLASH
       end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "2.7.7"
+    VERSION = "2.7.8"
   end
 end


### PR DESCRIPTION
https://blog.google/products/gemini/gemini-2-5-model-family-expands/

Per this article 2.5 Flash and 2.5 Pro are now GA. This swaps the tags to point to those versions.