### PR TITLE
Add unified thinking option for Gemini extended thinking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.3.3)
+    omniai-google (3.4.3)
       event_stream_parser
       google-cloud-storage
       googleauth
@@ -115,7 +115,7 @@ GEM
     multi_json (1.19.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    omniai (3.2.3)
+    omniai (3.3.3)
       base64
       event_stream_parser
       http

--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ end
 client.chat('Be poetic.', stream:)
 ```
 
+#### Extended Thinking
+
+Google Gemini 2.0+ models support extended thinking, which shows the model's reasoning process.
+
+```ruby
+# Enable thinking
+response = client.chat("What is 25 * 25?", model: "gemini-2.5-pro-preview-05-06", thinking: true)
+```
+
+#### Accessing Thinking Content
+
+```ruby
+response.choices.first.message.contents.each do |content|
+  case content
+  when OmniAI::Chat::Thinking
+    puts "Thinking: #{content.thinking}"
+  when OmniAI::Chat::Text
+    puts "Response: #{content.text}"
+  end
+end
+```
+
+#### Streaming with Thinking
+
+```ruby
+client.chat("What are the prime factors of 1234567?", model: "gemini-2.5-pro-preview-05-06", thinking: true, stream: $stdout)
+```
+
+[Google API Reference `thinking`](https://ai.google.dev/gemini-api/docs/thinking)
+
 ### Upload
 
 An upload is especially useful when processing audio / image / video / text files. To use:

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -65,6 +65,9 @@ module OmniAI
         context.deserializers[:content] = ContentSerializer.method(:deserialize)
 
         context.serializers[:tool] = ToolSerializer.method(:serialize)
+
+        context.serializers[:thinking] = ThinkingSerializer.method(:serialize)
+        context.deserializers[:thinking] = ThinkingSerializer.method(:deserialize)
       end
 
     protected
@@ -129,6 +132,7 @@ module OmniAI
           end
 
         data[:temperature] = @temperature if @temperature
+        data[:thinkingConfig] = thinking_config if thinking_config
 
         data = data.compact
         data unless data.empty?
@@ -142,6 +146,19 @@ module OmniAI
       # @return [String]
       def operation
         stream? ? "streamGenerateContent" : "generateContent"
+      end
+
+      # Translates unified thinking option to Google's thinkingConfig format.
+      # Example: `thinking: true` becomes `{ includeThoughts: true }`
+      # @return [Hash, nil]
+      def thinking_config
+        thinking = @options[:thinking]
+        return unless thinking
+
+        case thinking
+        when true then { includeThoughts: true }
+        when Hash then { includeThoughts: true }.merge(thinking)
+        end
       end
 
       # @return [Array<Message>]

--- a/lib/omniai/google/chat/content_serializer.rb
+++ b/lib/omniai/google/chat/content_serializer.rb
@@ -7,9 +7,10 @@ module OmniAI
       module ContentSerializer
         # @param data [Hash]
         # @param context [Context]
-        # @return [OmniAI::Chat::Text, OmniAI::Chat::ToolCall]
+        # @return [OmniAI::Chat::Text, OmniAI::Chat::Thinking, OmniAI::Chat::ToolCall]
         def self.deserialize(data, context:)
           case
+          when data["thought"] then OmniAI::Chat::Thinking.deserialize(data, context:)
           when data["text"] then data["text"]
           when data["functionCall"] then OmniAI::Chat::ToolCall.deserialize(data, context:)
           end

--- a/lib/omniai/google/chat/message_serializer.rb
+++ b/lib/omniai/google/chat/message_serializer.rb
@@ -27,6 +27,7 @@ module OmniAI
           role = data["role"]
           parts = arrayify(data["parts"]).map do |part|
             case
+            when part["thought"] then OmniAI::Chat::Thinking.deserialize(part, context:)
             when part["text"] then OmniAI::Chat::Text.deserialize(part, context:)
             when part["functionCall"] then OmniAI::Chat::ToolCall.deserialize(part, context:)
             when part["functionResponse"] then OmniAI::Chat::ToolCallResult.deserialize(part, context:)

--- a/lib/omniai/google/chat/thinking_serializer.rb
+++ b/lib/omniai/google/chat/thinking_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Google
+    class Chat
+      # Overrides thinking serialize / deserialize.
+      module ThinkingSerializer
+        # @param data [Hash]
+        # @param context [Context]
+        #
+        # @return [OmniAI::Chat::Thinking]
+        def self.deserialize(data, context: nil) # rubocop:disable Lint/UnusedMethodArgument
+          # Google uses "thought: true" as a flag, with content in "text"
+          OmniAI::Chat::Thinking.new(data["text"])
+        end
+
+        # @param thinking [OmniAI::Chat::Thinking]
+        # @param context [Context]
+        #
+        # @return [Hash]
+        def self.serialize(thinking, context: nil) # rubocop:disable Lint/UnusedMethodArgument
+          { thought: true, text: thinking.thinking }
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -67,8 +67,9 @@ module OmniAI
       # @yieldparam prompt [OmniAI::Chat::Prompt]
       #
       # @return [OmniAI::Chat::Completion]
-      def chat(messages = nil, model: Chat::DEFAULT_MODEL, temperature: nil, format: nil, stream: nil, tools: nil, &)
-        Chat.process!(messages, model:, temperature:, format:, stream:, tools:, client: self, &)
+      def chat(messages = nil, model: Chat::DEFAULT_MODEL, temperature: nil, format: nil, stream: nil, tools: nil,
+        **, &)
+        Chat.process!(messages, model:, temperature:, format:, stream:, tools:, client: self, **, &)
       end
 
       # @param io [File, String] required - a file or URL

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.3.3"
+    VERSION = "3.4.3"
   end
 end

--- a/spec/omniai/google/chat/thinking_serializer_spec.rb
+++ b/spec/omniai/google/chat/thinking_serializer_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::Google::Chat::ThinkingSerializer do
+  describe ".deserialize" do
+    it "extracts thinking from text field" do
+      data = { "thought" => true, "text" => "my reasoning" }
+      thinking = described_class.deserialize(data)
+
+      expect(thinking.thinking).to eq("my reasoning")
+    end
+
+    it "handles nil text" do
+      data = { "thought" => true, "text" => nil }
+      thinking = described_class.deserialize(data)
+
+      expect(thinking.thinking).to be_nil
+    end
+
+    it "initializes metadata as empty hash" do
+      data = { "thought" => true, "text" => "reasoning" }
+      thinking = described_class.deserialize(data)
+
+      expect(thinking.metadata).to eq({})
+    end
+  end
+
+  describe ".serialize" do
+    it "returns hash with thought flag and text" do
+      thinking = OmniAI::Chat::Thinking.new("reasoning")
+      result = described_class.serialize(thinking)
+
+      expect(result).to eq({ thought: true, text: "reasoning" })
+    end
+
+    it "handles nil thinking content" do
+      thinking = OmniAI::Chat::Thinking.new(nil)
+      result = described_class.serialize(thinking)
+
+      expect(result).to eq({ thought: true, text: nil })
+    end
+
+    it "always sets thought to true" do
+      thinking = OmniAI::Chat::Thinking.new("test")
+      result = described_class.serialize(thinking)
+
+      expect(result[:thought]).to be true
+    end
+  end
+end

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -149,6 +149,58 @@ RSpec.describe OmniAI::Google::Chat do
       it { expect(completion.text).to eql('{ "name": "Ringo" }') }
     end
 
+    context "with thinking: true option" do
+      subject(:completion) { described_class.process!(prompt, client:, model:, thinking: true) }
+
+      let(:prompt) { "Tell me a joke!" }
+
+      before do
+        stub_request(:post, "https://generativelanguage.googleapis.com/v1beta/models/#{model}:generateContent?key=...")
+          .with(body: {
+            generationConfig: { thinkingConfig: { includeThoughts: true } },
+            contents: [
+              { role: "user", parts: [{ text: "Tell me a joke!" }] },
+            ],
+          })
+          .to_return_json(body: {
+            candidates: [{
+              content: {
+                role: "assistant",
+                parts: [{ text: "Two elephants fall off a cliff. Boom! Boom!" }],
+              },
+            }],
+          })
+      end
+
+      it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+    end
+
+    context "with thinking: { thinkingBudget: 1024 } option" do
+      subject(:completion) { described_class.process!(prompt, client:, model:, thinking: { thinkingBudget: 1024 }) }
+
+      let(:prompt) { "Tell me a joke!" }
+
+      before do
+        stub_request(:post, "https://generativelanguage.googleapis.com/v1beta/models/#{model}:generateContent?key=...")
+          .with(body: {
+            generationConfig: { thinkingConfig: { includeThoughts: true, thinkingBudget: 1024 } },
+            contents: [
+              { role: "user", parts: [{ text: "Tell me a joke!" }] },
+            ],
+          })
+          .to_return_json(body: {
+            candidates: [{
+              content: {
+                role: "assistant",
+                parts: [{ text: "Two elephants fall off a cliff. Boom! Boom!" }],
+              },
+            }],
+          })
+      end
+
+      it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+    end
+
     context "when using files / URLs" do
       let(:io) { Tempfile.new }
 


### PR DESCRIPTION
Add unified thinking option for Gemini extended thinking

Implement support for Google's extended thinking feature through a unified thinking: option that works across all OmniAI providers.

Changes:
- Add thinking_config method to translate thinking: to thinkingConfig
- Support thinking: true for { includeThoughts: true }
- Support thinking: { thinkingBudget: N } for custom budgets
- Update ContentSerializer to handle Thinking content type
- Update stream handling for thinking deltas
- Add tests for thinking option translation
- Document extended thinking feature in README