### PR TITLE
Fix Style/HashAsLastArrayItem rubocop offense

### DIFF
--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -104,7 +104,7 @@ module OmniAI
         return unless tools?
 
         [
-          function_declarations: custom_tools.map { |tool| tool.serialize(context:) },
+          { function_declarations: custom_tools.map { |tool| tool.serialize(context:) } },
         ].concat(internal_tools.map { |name| { name => {} } })
       end
 


### PR DESCRIPTION
## Summary
- Auto-corrected pre-existing `Style/HashAsLastArrayItem` rubocop offense in the `tools` method

## Test plan
- [x] `bundle exec rubocop` passes with 0 offenses
- [x] `bundle exec rspec spec/omniai/google/chat_spec.rb` — 11 examples, 0 failures