### PR TITLE
Add gemini-embedding models with Vertex endpoint routing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.6.0)
+    omniai-google (3.7.0)
       event_stream_parser
       google-cloud-storage
       googleauth
@@ -116,7 +116,11 @@ GEM
     multi_json (1.19.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
+<<<<<<< HEAD
     omniai (3.5.0)
+=======
+    omniai (3.4.0)
+>>>>>>> a7c2b81 (Add gemini-embedding-001 and gemini-embedding-2-preview models)
       base64
       event_stream_parser
       http (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.0)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -27,7 +27,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    erb (6.0.1)
+    erb (6.0.2)
     event_stream_parser (1.0.0)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
@@ -116,11 +116,7 @@ GEM
     multi_json (1.19.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-<<<<<<< HEAD
-    omniai (3.5.0)
-=======
-    omniai (3.4.0)
->>>>>>> a7c2b81 (Add gemini-embedding-001 and gemini-embedding-2-preview models)
+    omniai (3.6.0)
       base64
       event_stream_parser
       http (~> 5)
@@ -129,7 +125,7 @@ GEM
     openssl (4.0.1)
     os (1.1.4)
     parallel (1.27.0)
-    parser (3.3.10.2)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -166,10 +162,10 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.86.0)

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -85,8 +85,9 @@ module OmniAI
       #
       # @param input [String, Array<String>, Array<Integer>] required
       # @param model [String] optional
-      def embed(input, model: Embed::DEFAULT_MODEL)
-        Embed.process!(input, model:, client: self)
+      # @param options [Hash] provider-specific options (e.g. task_type: "RETRIEVAL_DOCUMENT")
+      def embed(input, model: Embed::DEFAULT_MODEL, **options)
+        Embed.process!(input, model:, client: self, **options)
       end
 
       # @raise [OmniAI::Error]

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -2,7 +2,7 @@
 
 module OmniAI
   module Google
-    # An Google embed implementation.
+    # A Google embed implementation.
     #
     # Usage:
     #
@@ -14,67 +14,124 @@ module OmniAI
         TEXT_EMBEDDING_004 = "text-embedding-004"
         TEXT_EMBEDDING_005 = "text-embedding-005"
         TEXT_MULTILINGUAL_EMBEDDING_002 = "text-multilingual-embedding-002"
+        GEMINI_EMBEDDING_001 = "gemini-embedding-001"
+        GEMINI_EMBEDDING_2_PREVIEW = "gemini-embedding-2-preview"
         EMBEDDING = TEXT_EMBEDDING_004
         MULTILINGUAL_EMBEDDING = TEXT_MULTILINGUAL_EMBEDDING_002
       end
 
       DEFAULT_MODEL = Model::EMBEDDING
 
-      DEFAULT_EMBEDDINGS_DESERIALIZER = proc do |data, *|
+      BATCH_EMBED_CONTENTS_DESERIALIZER = proc do |data, *|
         data["embeddings"].map { |embedding| embedding["values"] }
       end
 
-      VERTEX_EMBEDDINGS_DESERIALIZER = proc do |data, *|
+      PREDICT_EMBEDDINGS_DESERIALIZER = proc do |data, *|
         data["predictions"].map { |prediction| prediction["embeddings"]["values"] }
       end
 
-      VERTEX_USAGE_DESERIALIZER = proc do |data, *|
-        tokens = data["predictions"].map { |prediction| prediction["embeddings"]["statistics"]["token_count"] }.sum
+      PREDICT_USAGE_DESERIALIZER = proc do |data, *|
+        tokens = data["predictions"].sum { |prediction| prediction["embeddings"]["statistics"]["token_count"] }
 
         Usage.new(prompt_tokens: tokens, total_tokens: tokens)
       end
 
-      # @return [Context]
-      DEFAULT_CONTEXT = Context.build do |context|
-        context.deserializers[:embeddings] = DEFAULT_EMBEDDINGS_DESERIALIZER
+      EMBED_CONTENT_DESERIALIZER = proc do |data, *|
+        [data["embedding"]["values"]]
+      end
+
+      USAGE_METADATA_DESERIALIZER = proc do |data, *|
+        prompt_tokens = data.dig("usageMetadata", "promptTokenCount")
+        total_tokens = data.dig("usageMetadata", "totalTokenCount")
+
+        Usage.new(prompt_tokens: prompt_tokens, total_tokens: total_tokens)
       end
 
       # @return [Context]
-      VERTEX_CONTEXT = Context.build do |context|
-        context.deserializers[:embeddings] = VERTEX_EMBEDDINGS_DESERIALIZER
-        context.deserializers[:usage] = VERTEX_USAGE_DESERIALIZER
+      BATCH_EMBED_CONTENTS_CONTEXT = Context.build do |context|
+        context.deserializers[:embeddings] = BATCH_EMBED_CONTENTS_DESERIALIZER
+        context.deserializers[:usage] = USAGE_METADATA_DESERIALIZER
+      end
+
+      # @return [Context]
+      PREDICT_CONTEXT = Context.build do |context|
+        context.deserializers[:embeddings] = PREDICT_EMBEDDINGS_DESERIALIZER
+        context.deserializers[:usage] = PREDICT_USAGE_DESERIALIZER
+      end
+
+      # @return [Context]
+      EMBED_CONTENT_CONTEXT = Context.build do |context|
+        context.deserializers[:embeddings] = EMBED_CONTENT_DESERIALIZER
+        context.deserializers[:usage] = USAGE_METADATA_DESERIALIZER
       end
 
     protected
 
-      # @return [Boolean]
-      def vertex?
-        @client.vertex?
+      # Determines which endpoint to use based on client and model configuration.
+      # Routes gemini-embedding-2-* models to embedContent on Vertex, as Google's
+      # Vertex AI requires this endpoint for newer multimodal embedding models.
+      #
+      # @return [Symbol] :embed_content, :predict, or :batch_embed_contents
+      def endpoint
+        @endpoint ||= if @client.vertex? && @model.start_with?("gemini-embedding-2")
+          :embed_content
+        elsif @client.vertex?
+          :predict
+        else
+          :batch_embed_contents
+        end
       end
 
       # @return [Context]
       def context
-        vertex? ? VERTEX_CONTEXT : DEFAULT_CONTEXT
-      end
-
-      # @return [Array[Hash]]
-      def instances
-        arrayify(@input).map { |content| { content: } }
-      end
-
-      # @return [Array[Hash]]
-      def requests
-        arrayify(@input).map do |text|
-          {
-            model: "models/#{@model}",
-            content: { parts: [{ text: }] },
-          }
+        case endpoint
+        when :embed_content then EMBED_CONTENT_CONTEXT
+        when :predict then PREDICT_CONTEXT
+        when :batch_embed_contents then BATCH_EMBED_CONTENTS_CONTEXT
         end
       end
 
       # @return [Hash]
       def payload
-        vertex? ? { instances: } : { requests: }
+        case endpoint
+        when :embed_content then embed_content_payload
+        when :predict then predict_payload
+        when :batch_embed_contents then batch_embed_contents_payload
+        end
+      end
+
+      # Builds payload for the Vertex embedContent endpoint (gemini-embedding-2-* models).
+      # @return [Hash]
+      def embed_content_payload
+        raise ArgumentError, "embedContent does not support batch input" if @input.is_a?(Array) && @input.length > 1
+
+        text = @input.is_a?(Array) ? @input.first : @input
+        result = { content: { parts: [{ text: text }] } }
+        result[:taskType] = @options[:task_type] if @options[:task_type]
+        result
+      end
+
+      # Builds payload for the Vertex predict endpoint (text-embedding and gemini-embedding-001 models).
+      # @return [Hash]
+      def predict_payload
+        inputs = arrayify(@input)
+        { instances: inputs.map { |text| { content: text } } }
+      end
+
+      # Builds payload for the Google AI batchEmbedContents endpoint (non-Vertex).
+      # @return [Hash]
+      def batch_embed_contents_payload
+        inputs = arrayify(@input)
+        {
+          requests: inputs.map do |text|
+            request = {
+              model: "models/#{@model}",
+              content: { parts: [{ text: text }] },
+            }
+            request[:taskType] = @options[:task_type] if @options[:task_type]
+            request
+          end
+        }
       end
 
       # @return [Hash]
@@ -84,18 +141,13 @@ module OmniAI
 
       # @return [String]
       def path
+        procedure = case endpoint
+                    when :embed_content then "embedContent"
+                    when :predict then "predict"
+                    when :batch_embed_contents then "batchEmbedContents"
+                    end
+
         "/#{@client.path}/models/#{@model}:#{procedure}"
-      end
-
-      # @return [String]
-      def procedure
-        vertex? ? "predict" : "batchEmbedContents"
-      end
-
-      # @param input [Object]
-      # @return [Array]
-      def arrayify(input)
-        input.is_a?(Array) ? input : [input]
       end
     end
   end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.6.0"
+    VERSION = "3.7.0"
   end
 end

--- a/spec/omniai/google/embed_spec.rb
+++ b/spec/omniai/google/embed_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe OmniAI::Google::Embed do
     let(:location) { OmniAI::Google::Config::DEFAULT_LOCATION }
 
     before do
-      stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/text-embedding-004:batchEmbedContents?key=...")
+      stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/#{model}:batchEmbedContents?key=...")
         .with(body: {
           requests: [
             {
               model: "models/#{model}",
-              content: { parts: [{ text: }] },
+              content: { parts: [{ text: text }] },
             },
           ],
         })
@@ -26,5 +26,150 @@ RSpec.describe OmniAI::Google::Embed do
 
     it { expect(process!).to be_a(OmniAI::Embed::Response) }
     it { expect(process!.embedding).to eql([0.0]) }
+
+    context "with gemini-embedding-001" do
+      let(:model) { described_class::Model::GEMINI_EMBEDDING_001 }
+
+      it { expect(process!).to be_a(OmniAI::Embed::Response) }
+      it { expect(process!.embedding).to eql([0.0]) }
+    end
+
+    context "with gemini-embedding-2-preview" do
+      let(:model) { described_class::Model::GEMINI_EMBEDDING_2_PREVIEW }
+
+      it { expect(process!).to be_a(OmniAI::Embed::Response) }
+      it { expect(process!.embedding).to eql([0.0]) }
+    end
+
+    context "with text-embedding-005" do
+      let(:model) { described_class::Model::TEXT_EMBEDDING_005 }
+
+      it { expect(process!).to be_a(OmniAI::Embed::Response) }
+      it { expect(process!.embedding).to eql([0.0]) }
+    end
+
+    context "with batch input (batchEmbedContents)" do
+      subject(:process!) { described_class.process!(texts, client:, model:) }
+
+      let(:texts) { ["Hello", "World"] }
+
+      before do
+        stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/#{model}:batchEmbedContents?key=...")
+          .with(body: {
+            requests: [
+              { model: "models/#{model}", content: { parts: [{ text: "Hello" }] } },
+              { model: "models/#{model}", content: { parts: [{ text: "World" }] } },
+            ],
+          })
+          .to_return_json(body: { embeddings: [{ values: [0.1] }, { values: [0.2] }] })
+      end
+
+      it { expect(process!.embeddings).to eql([[0.1], [0.2]]) }
+    end
+
+    context "without task_type (batchEmbedContents)" do
+      it "does not include taskType in the payload" do
+        embed = described_class.new(text, client: client, model: model)
+        payload = embed.send(:batch_embed_contents_payload)
+        expect(payload[:requests].first).not_to have_key(:taskType)
+      end
+    end
+
+    context "with task_type (batchEmbedContents)" do
+      subject(:process!) { described_class.process!(text, client:, model:, task_type: "RETRIEVAL_DOCUMENT") }
+
+      before do
+        stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/#{model}:batchEmbedContents?key=...")
+          .with(body: {
+            requests: [
+              {
+                model: "models/#{model}",
+                content: { parts: [{ text: text }] },
+                taskType: "RETRIEVAL_DOCUMENT",
+              },
+            ],
+          })
+          .to_return_json(body: { embeddings: [{ values: [0.0] }] })
+      end
+
+      it { expect(process!).to be_a(OmniAI::Embed::Response) }
+      it { expect(process!.embedding).to eql([0.0]) }
+    end
+
+    context "with vertex" do
+      let(:client) do
+        OmniAI::Google::Client.new(
+          credentials: credentials,
+          host: "https://us-central1-aiplatform.googleapis.com",
+          project_id: "test-project",
+          location_id: "us-central1"
+        )
+      end
+
+      let(:credentials) do
+        instance_double(Google::Auth::ServiceAccountCredentials, fetch_access_token!: nil, access_token: "token")
+      end
+
+      context "with gemini-embedding-001 (predict)" do
+        let(:model) { described_class::Model::GEMINI_EMBEDDING_001 }
+
+        before do
+          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:predict")
+            .with(body: {
+              instances: [{ content: text }],
+            })
+            .to_return_json(body: { predictions: [{ embeddings: { values: [0.0], statistics: { token_count: 10 } } }] })
+        end
+
+        it { expect(process!).to be_a(OmniAI::Embed::Response) }
+        it { expect(process!.embedding).to eql([0.0]) }
+        it { expect(process!.usage.total_tokens).to eql(10) }
+      end
+
+      context "with gemini-embedding-2-preview (embedContent)" do
+        let(:model) { described_class::Model::GEMINI_EMBEDDING_2_PREVIEW }
+
+        before do
+          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
+            .with(body: {
+              content: { parts: [{ text: text }] },
+            })
+            .to_return_json(body: {
+              embedding: { values: [0.0] },
+              usageMetadata: { promptTokenCount: 5, totalTokenCount: 5 },
+            })
+        end
+
+        it { expect(process!).to be_a(OmniAI::Embed::Response) }
+        it { expect(process!.embedding).to eql([0.0]) }
+        it { expect(process!.usage.total_tokens).to eql(5) }
+        it { expect(process!.usage.prompt_tokens).to eql(5) }
+
+        context "with task_type" do
+          subject(:process!) { described_class.process!(text, client:, model:, task_type: "RETRIEVAL_QUERY") }
+
+          before do
+            stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
+              .with(body: {
+                content: { parts: [{ text: text }] },
+                taskType: "RETRIEVAL_QUERY",
+              })
+              .to_return_json(body: {
+                embedding: { values: [0.0] },
+                usageMetadata: { promptTokenCount: 5, totalTokenCount: 5 },
+              })
+          end
+
+          it { expect(process!).to be_a(OmniAI::Embed::Response) }
+          it { expect(process!.embedding).to eql([0.0]) }
+        end
+
+        context "with batch input" do
+          let(:text) { ["Hello", "World"] }
+
+          it { expect { process! }.to raise_error(ArgumentError, "embedContent does not support batch input") }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add `GEMINI_EMBEDDING_001` and `GEMINI_EMBEDDING_2_PREVIEW` model constants
- Route `gemini-embedding-2-*` models to `embedContent` endpoint on Vertex AI (older models continue using `predict`)
- Add `task_type` option support (e.g. `RETRIEVAL_DOCUMENT`, `RETRIEVAL_QUERY`) for `embedContent` and `batchEmbedContents`
- Add usage deserialization for all three endpoint types (`embedContent`, `predict`, `batchEmbedContents`)
- Guard against batch input on `embedContent` (single-input endpoint)
- Bump version to 3.7.0

Depends on ksylvest/omniai#266 (adds `**options` to base `Embed` class).

### Vertex AI notes
- `gemini-embedding-2-preview` requires a location-prefixed host (e.g. `https://us-central1-aiplatform.googleapis.com`)
- `gemini-embedding-001` works with `predict` on either host format
- `gemini-embedding-001` does NOT support `embedContent` on Vertex

## Test plan
- [ ] Verify `bundle exec rspec spec/omniai/google/embed_spec.rb` passes (22 examples, 0 failures)
- [ ] Verify all models work against real Vertex AI (tested: gemini-embedding-001, gemini-embedding-2-preview, text-embedding-004, text-embedding-005)
- [ ] Verify task_type appears in payload when provided, absent when omitted
- [ ] Verify batch input raises ArgumentError on embedContent