### PR TITLE
Fix rubocop offenses and bump to 3.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.7.0)
+    omniai-google (3.7.1)
       event_stream_parser
       google-cloud-storage
       googleauth

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -86,8 +86,8 @@ module OmniAI
       # @param input [String, Array<String>, Array<Integer>] required
       # @param model [String] optional
       # @param options [Hash] provider-specific options (e.g. task_type: "RETRIEVAL_DOCUMENT")
-      def embed(input, model: Embed::DEFAULT_MODEL, **options)
-        Embed.process!(input, model:, client: self, **options)
+      def embed(input, model: Embed::DEFAULT_MODEL, **)
+        Embed.process!(input, model:, client: self, **)
       end
 
       # @raise [OmniAI::Error]

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -44,7 +44,7 @@ module OmniAI
         prompt_tokens = data.dig("usageMetadata", "promptTokenCount")
         total_tokens = data.dig("usageMetadata", "totalTokenCount")
 
-        Usage.new(prompt_tokens: prompt_tokens, total_tokens: total_tokens)
+        Usage.new(prompt_tokens:, total_tokens:)
       end
 
       # @return [Context]
@@ -73,13 +73,14 @@ module OmniAI
       #
       # @return [Symbol] :embed_content, :predict, or :batch_embed_contents
       def endpoint
-        @endpoint ||= if @client.vertex? && @model.start_with?("gemini-embedding-2")
-          :embed_content
-        elsif @client.vertex?
-          :predict
-        else
-          :batch_embed_contents
-        end
+        @endpoint ||=
+          if @client.vertex? && @model.start_with?("gemini-embedding-2")
+            :embed_content
+          elsif @client.vertex?
+            :predict
+          else
+            :batch_embed_contents
+          end
       end
 
       # @return [Context]
@@ -106,7 +107,7 @@ module OmniAI
         raise ArgumentError, "embedContent does not support batch input" if @input.is_a?(Array) && @input.length > 1
 
         text = @input.is_a?(Array) ? @input.first : @input
-        result = { content: { parts: [{ text: text }] } }
+        result = { content: { parts: [{ text: }] } }
         result[:taskType] = @options[:task_type] if @options[:task_type]
         result
       end
@@ -126,11 +127,11 @@ module OmniAI
           requests: inputs.map do |text|
             request = {
               model: "models/#{@model}",
-              content: { parts: [{ text: text }] },
+              content: { parts: [{ text: }] },
             }
             request[:taskType] = @options[:task_type] if @options[:task_type]
             request
-          end
+          end,
         }
       end
 
@@ -139,15 +140,15 @@ module OmniAI
         { key: (@client.api_key unless @client.credentials?) }.compact
       end
 
+      PROCEDURES = {
+        embed_content: "embedContent",
+        predict: "predict",
+        batch_embed_contents: "batchEmbedContents",
+      }.freeze
+
       # @return [String]
       def path
-        procedure = case endpoint
-                    when :embed_content then "embedContent"
-                    when :predict then "predict"
-                    when :batch_embed_contents then "batchEmbedContents"
-                    end
-
-        "/#{@client.path}/models/#{@model}:#{procedure}"
+        "/#{@client.path}/models/#{@model}:#{PROCEDURES[endpoint]}"
       end
     end
   end

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.7.0"
+    VERSION = "3.7.1"
   end
 end

--- a/spec/omniai/google/embed_spec.rb
+++ b/spec/omniai/google/embed_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe OmniAI::Google::Embed do
           requests: [
             {
               model: "models/#{model}",
-              content: { parts: [{ text: text }] },
+              content: { parts: [{ text: }] },
             },
           ],
         })
@@ -51,7 +51,7 @@ RSpec.describe OmniAI::Google::Embed do
     context "with batch input (batchEmbedContents)" do
       subject(:process!) { described_class.process!(texts, client:, model:) }
 
-      let(:texts) { ["Hello", "World"] }
+      let(:texts) { %w[Hello World] }
 
       before do
         stub_request(:post, "https://generativelanguage.googleapis.com//v1beta/models/#{model}:batchEmbedContents?key=...")
@@ -69,7 +69,7 @@ RSpec.describe OmniAI::Google::Embed do
 
     context "without task_type (batchEmbedContents)" do
       it "does not include taskType in the payload" do
-        embed = described_class.new(text, client: client, model: model)
+        embed = described_class.new(text, client:, model:)
         payload = embed.send(:batch_embed_contents_payload)
         expect(payload[:requests].first).not_to have_key(:taskType)
       end
@@ -84,7 +84,7 @@ RSpec.describe OmniAI::Google::Embed do
             requests: [
               {
                 model: "models/#{model}",
-                content: { parts: [{ text: text }] },
+                content: { parts: [{ text: }] },
                 taskType: "RETRIEVAL_DOCUMENT",
               },
             ],
@@ -99,7 +99,7 @@ RSpec.describe OmniAI::Google::Embed do
     context "with vertex" do
       let(:client) do
         OmniAI::Google::Client.new(
-          credentials: credentials,
+          credentials:,
           host: "https://us-central1-aiplatform.googleapis.com",
           project_id: "test-project",
           location_id: "us-central1"
@@ -110,7 +110,7 @@ RSpec.describe OmniAI::Google::Embed do
         instance_double(Google::Auth::ServiceAccountCredentials, fetch_access_token!: nil, access_token: "token")
       end
 
-      context "with gemini-embedding-001 (predict)" do
+      context "with gemini-embedding-001 (predict)" do # rubocop:disable RSpec/NestedGroups
         let(:model) { described_class::Model::GEMINI_EMBEDDING_001 }
 
         before do
@@ -123,16 +123,16 @@ RSpec.describe OmniAI::Google::Embed do
 
         it { expect(process!).to be_a(OmniAI::Embed::Response) }
         it { expect(process!.embedding).to eql([0.0]) }
-        it { expect(process!.usage.total_tokens).to eql(10) }
+        it { expect(process!.usage.total_tokens).to be(10) }
       end
 
-      context "with gemini-embedding-2-preview (embedContent)" do
+      context "with gemini-embedding-2-preview (embedContent)" do # rubocop:disable RSpec/NestedGroups
         let(:model) { described_class::Model::GEMINI_EMBEDDING_2_PREVIEW }
 
         before do
           stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
             .with(body: {
-              content: { parts: [{ text: text }] },
+              content: { parts: [{ text: }] },
             })
             .to_return_json(body: {
               embedding: { values: [0.0] },
@@ -142,16 +142,16 @@ RSpec.describe OmniAI::Google::Embed do
 
         it { expect(process!).to be_a(OmniAI::Embed::Response) }
         it { expect(process!.embedding).to eql([0.0]) }
-        it { expect(process!.usage.total_tokens).to eql(5) }
-        it { expect(process!.usage.prompt_tokens).to eql(5) }
+        it { expect(process!.usage.total_tokens).to be(5) }
+        it { expect(process!.usage.prompt_tokens).to be(5) }
 
-        context "with task_type" do
+        context "with task_type" do # rubocop:disable RSpec/NestedGroups
           subject(:process!) { described_class.process!(text, client:, model:, task_type: "RETRIEVAL_QUERY") }
 
           before do
             stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
               .with(body: {
-                content: { parts: [{ text: text }] },
+                content: { parts: [{ text: }] },
                 taskType: "RETRIEVAL_QUERY",
               })
               .to_return_json(body: {
@@ -164,8 +164,8 @@ RSpec.describe OmniAI::Google::Embed do
           it { expect(process!.embedding).to eql([0.0]) }
         end
 
-        context "with batch input" do
-          let(:text) { ["Hello", "World"] }
+        context "with batch input" do # rubocop:disable RSpec/NestedGroups
+          let(:text) { %w[Hello World] }
 
           it { expect { process! }.to raise_error(ArgumentError, "embedContent does not support batch input") }
         end


### PR DESCRIPTION
## Summary
- Fix all rubocop offenses from the v3.7.0 release
- Bump version to 3.7.1

Rubocop fixes: shorthand hash syntax, anonymous keyword forwarding, indentation alignment, hash lookup for PROCEDURES constant, trailing commas, %w arrays, be vs eql for integers, NestedGroups disables for Vertex test contexts.

## Test plan
- [ ] Rubocop passes with no offenses
- [ ] All 22 embed specs pass