### PR TITLE
Add gemini-3.5-flash model and make it the default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.7.2)
+    omniai-google (3.8.0)
       event_stream_parser
       google-cloud-storage
       googleauth

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ completion.text # 'The capital of Canada is Ottawa.'
 
 #### Model
 
-`model` takes an optional string (default is `gemini-3-flash-preview`):
+`model` takes an optional string (default is `gemini-3.5-flash`):
 
 ```ruby
 completion = client.chat('How fast is a cheetah?', model: OmniAI::Google::Chat::Model::GEMINI_FLASH)

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -22,11 +22,12 @@ module OmniAI
         GEMINI_2_0_FLASH = "gemini-2.0-flash"
         GEMINI_2_5_FLASH = "gemini-2.5-flash"
         GEMINI_3_FLASH = "gemini-3-flash-preview"
+        GEMINI_3_5_FLASH = "gemini-3.5-flash"
         GEMINI_PRO = GEMINI_3_1_PRO
-        GEMINI_FLASH = GEMINI_3_FLASH
+        GEMINI_FLASH = GEMINI_3_5_FLASH
       end
 
-      DEFAULT_MODEL = Model::GEMINI_3_FLASH
+      DEFAULT_MODEL = Model::GEMINI_3_5_FLASH
 
       module ResponseMimeType
         JSON = "application/json"

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.7.2"
+    VERSION = "3.8.0"
   end
 end


### PR DESCRIPTION
## Summary

- Add `Model::GEMINI_3_5_FLASH = "gemini-3.5-flash"` to `OmniAI::Google::Chat::Model`.
- Repoint the `GEMINI_FLASH` alias and `DEFAULT_MODEL` to `GEMINI_3_5_FLASH`. `gemini-3.5-flash` is GA (no `-preview` suffix), so it replaces the `gemini-3-flash-preview` build as the default flash model.
- Update the README default model string.
- Bump version `3.7.2` → `3.8.0` (minor: new model + default-behavior change).

## Behavior change

Callers relying on defaults (`client.chat(...)` with no `model:`, or `Model::GEMINI_FLASH`) now resolve to `gemini-3.5-flash` instead of `gemini-3-flash-preview`. Versioned constants (`GEMINI_3_FLASH`, etc.) are unchanged, so anyone pinned to a specific model is unaffected.

## Verification

- Live: a `gemini-3.5-flash` chat call against Vertex AI returns `modelVersion: "gemini-3.5-flash"`.
- `bundle exec rspec` → 243 examples, 0 failures.