### PR TITLE
Populate normalized finish_reason from Google finishReason (+ fix streaming drop)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.9.0)
+    omniai-google (3.10.0)
       event_stream_parser
       google-cloud-storage
       googleauth
-      omniai (~> 3.2)
+      omniai (~> 3.7)
       openssl
       zeitwerk
 
@@ -115,7 +115,7 @@ GEM
     mini_mime (1.1.5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    omniai (3.6.0)
+    omniai (3.7.0)
       base64
       event_stream_parser
       http (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     omniai (3.7.0)
       base64
       event_stream_parser
-      http (~> 5)
+      http (>= 5, < 7)
       logger
       zeitwerk
     openssl (4.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.1.0)
+    bigdecimal (4.1.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -37,31 +37,18 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    ffi (1.17.4)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-aarch64-linux-musl)
-    ffi (1.17.4-arm-linux-gnu)
-    ffi (1.17.4-arm-linux-musl)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86-linux-gnu)
-    ffi (1.17.4-x86-linux-musl)
-    ffi (1.17.4-x86_64-darwin)
-    ffi (1.17.4-x86_64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-musl)
-    ffi-compiler (1.3.2)
-      ffi (>= 1.15.5)
-      rake
-    google-apis-core (1.0.2)
+    google-apis-core (1.2.2)
       addressable (~> 2.8, >= 2.8.7)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
+      multi_json (~> 1.11)
       representable (~> 3.0)
-      retriable (~> 3.1)
+      retriable (>= 3.1, < 5.0)
     google-apis-iamcredentials_v1 (0.27.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.62.0)
+    google-apis-storage_v1 (0.63.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)
@@ -89,14 +76,11 @@ GEM
       pstore (~> 0.1)
       signet (>= 0.16, < 2.a)
     hashdiff (1.2.1)
-    http (5.3.1)
-      addressable (~> 2.8)
+    http (6.0.3)
       http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
-    http-cookie (1.1.0)
+      llhttp (~> 0.6.1)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
-    http-form_data (2.3.0)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -108,11 +92,10 @@ GEM
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    llhttp-ffi (0.5.1)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
+    llhttp (0.6.1)
     logger (1.7.0)
     mini_mime (1.1.5)
+    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     omniai (3.7.0)
@@ -132,7 +115,7 @@ GEM
     prettyprint (0.2.0)
     prism (1.9.0)
     pstore (0.2.1)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -151,7 +134,7 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.4.1)
+    retriable (4.1.1)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -217,17 +200,8 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
+  arm64-darwin-24
   ruby
-  x86-linux-gnu
-  x86-linux-musl
-  x86_64-darwin
-  x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   irb

--- a/lib/omniai/google/chat/choice_serializer.rb
+++ b/lib/omniai/google/chat/choice_serializer.rb
@@ -5,6 +5,20 @@ module OmniAI
     class Chat
       # Overrides choice serialize / deserialize.
       module ChoiceSerializer
+        # Maps Gemini candidate `finishReason` values onto the normalized OmniAI::Chat::FinishReason symbols. The
+        # entire content-policy / safety family maps to `:filter`; unrecognized values (e.g. OTHER,
+        # MALFORMED_FUNCTION_CALL, FINISH_REASON_UNSPECIFIED) fall through to `:other`.
+        FINISH_REASONS = {
+          "STOP" => OmniAI::Chat::FinishReason::STOP,
+          "MAX_TOKENS" => OmniAI::Chat::FinishReason::LENGTH,
+          "SAFETY" => OmniAI::Chat::FinishReason::FILTER,
+          "RECITATION" => OmniAI::Chat::FinishReason::FILTER,
+          "LANGUAGE" => OmniAI::Chat::FinishReason::FILTER,
+          "BLOCKLIST" => OmniAI::Chat::FinishReason::FILTER,
+          "PROHIBITED_CONTENT" => OmniAI::Chat::FinishReason::FILTER,
+          "SPII" => OmniAI::Chat::FinishReason::FILTER,
+          "IMAGE_SAFETY" => OmniAI::Chat::FinishReason::FILTER,
+        }.freeze
         # @param choice [OmniAI::Chat::Choice]
         # @param context [Context]
         # @return [Hash]
@@ -18,7 +32,8 @@ module OmniAI
         # @return [OmniAI::Chat::Choice]
         def self.deserialize(data, context:)
           message = OmniAI::Chat::Message.deserialize(data["content"], context:)
-          OmniAI::Chat::Choice.new(message:)
+          finish_reason = OmniAI::Chat::FinishReason.deserialize(data["finishReason"], table: FINISH_REASONS)
+          OmniAI::Chat::Choice.new(message:, finish_reason:)
         end
       end
     end

--- a/lib/omniai/google/chat/stream.rb
+++ b/lib/omniai/google/chat/stream.rb
@@ -55,9 +55,7 @@ module OmniAI
         # @param candidate [Hash]
         # @param index [Integer]
         def process_candidate!(candidate:, index:, &block)
-          return unless candidate["content"]
-
-          candidate["content"]["parts"]&.each do |part|
+          candidate.dig("content", "parts")&.each do |part|
             if part["thought"]
               block&.call(OmniAI::Chat::Delta.new(thinking: part["text"]))
             elsif part["text"]
@@ -73,16 +71,29 @@ module OmniAI
         def merge_candidate!(candidate:, index:)
           if @data["candidates"][index].nil?
             @data["candidates"][index] = candidate
-          else
-            (candidate["content"]["parts"] || []).each do |part|
-              merge_part!(part:, candidate: @data["candidates"][index])
-            end
+            return
+          end
+
+          existing = @data["candidates"][index]
+
+          candidate.dig("content", "parts")&.each do |part|
+            merge_part!(part:, candidate: existing)
+          end
+
+          # Preserve top-level candidate keys (most importantly `finishReason`) that arrive on a later — usually
+          # terminal — chunk after the content has already streamed. Without this, the reason a generation stopped
+          # (e.g. MAX_TOKENS / SAFETY) is silently dropped from the assembled response.
+          candidate.each do |key, value|
+            next if key.eql?("content")
+
+            existing[key] = value
           end
         end
 
         # @param part [Hash]
         # @param candidate [Hash]
         def merge_part!(part:, candidate:)
+          candidate["content"] ||= {}
           parts = candidate["content"]["parts"] ||= []
           last_part = parts.last
 

--- a/lib/omniai/google/transcribe.rb
+++ b/lib/omniai/google/transcribe.rb
@@ -113,7 +113,7 @@ module OmniAI
         # Speech-to-Text API uses different endpoints for regional vs global
         endpoint = speech_endpoint
         speech_connection = HTTP.persistent(endpoint)
-          .timeout(**http_timeout_options)
+          .timeout(http_timeout_options)
           .accept(:json)
 
         # Add authentication if using credentials

--- a/lib/omniai/google/transcribe_helpers.rb
+++ b/lib/omniai/google/transcribe_helpers.rb
@@ -45,12 +45,14 @@ module OmniAI
       # Normalizes the client timeout into keyword args for HTTP.rb's `.timeout`. The speech
       # endpoints build their own connections, so (unlike the base client, which passes the
       # value straight through) they must accept both a scalar and a per-operation Hash. A Hash
-      # is passed through untouched; a scalar (or nil) is wrapped per-operation as before.
+      # is passed through untouched; a scalar is wrapped per-operation. When no timeout is set, returns `:null`
+      # (the http "no timeout" sentinel) — http 6 rejects nil per-operation values, http 5 accepts `:null` too.
       #
-      # @return [Hash]
+      # @return [Hash, Symbol]
       def http_timeout_options
         timeout = @client.timeout
         return timeout if timeout.is_a?(Hash)
+        return :null if timeout.nil?
 
         { connect: timeout, write: timeout, read: timeout }
       end
@@ -212,7 +214,7 @@ module OmniAI
       def poll_operation!(operation_name)
         endpoint = speech_endpoint
         connection = HTTP.persistent(endpoint)
-          .timeout(**http_timeout_options)
+          .timeout(http_timeout_options)
           .accept(:json)
 
         # Add authentication if using credentials
@@ -250,7 +252,7 @@ module OmniAI
       def request_batch!
         endpoint = speech_endpoint
         connection = HTTP.persistent(endpoint)
-          .timeout(**http_timeout_options)
+          .timeout(http_timeout_options)
           .accept(:json)
 
         # Add authentication if using credentials

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.9.0"
+    VERSION = "3.10.0"
   end
 end

--- a/omniai-google.gemspec
+++ b/omniai-google.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "event_stream_parser"
   spec.add_dependency "googleauth"
   spec.add_dependency "google-cloud-storage"
-  spec.add_dependency "omniai", "~> 3.2"
+  spec.add_dependency "omniai", "~> 3.7"
   spec.add_dependency "openssl"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/google/chat/choice_serializer_spec.rb
+++ b/spec/omniai/google/chat/choice_serializer_spec.rb
@@ -26,4 +26,48 @@ RSpec.describe OmniAI::Google::Chat::ChoiceSerializer do
 
     it { is_expected.to be_a(OmniAI::Chat::Choice) }
   end
+
+  describe ".deserialize finish_reason mapping" do
+    subject(:finish_reason) { described_class.deserialize(data, context:).finish_reason }
+
+    let(:data) do
+      {
+        "content" => { "role" => "model", "parts" => [{ "text" => "Hello!" }] },
+        "finishReason" => raw,
+      }
+    end
+
+    {
+      "STOP" => :stop,
+      "MAX_TOKENS" => :length,
+      "SAFETY" => :filter,
+      "RECITATION" => :filter,
+      "LANGUAGE" => :filter,
+      "BLOCKLIST" => :filter,
+      "PROHIBITED_CONTENT" => :filter,
+      "SPII" => :filter,
+      "IMAGE_SAFETY" => :filter,
+      "OTHER" => :other,
+      "MALFORMED_FUNCTION_CALL" => :other,
+      "SOMETHING_NEW" => :other,
+    }.each do |raw, expected|
+      context "when finishReason is #{raw.inspect}" do
+        let(:raw) { raw }
+
+        it "normalizes the reason" do
+          expect(finish_reason.reason).to eq(expected)
+        end
+
+        it "preserves the verbatim value" do
+          expect(finish_reason.value).to eq(raw)
+        end
+      end
+    end
+
+    context "when finishReason is absent" do
+      let(:data) { { "content" => { "role" => "model", "parts" => [{ "text" => "Hello!" }] } } }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/omniai/google/chat/stream_spec.rb
+++ b/spec/omniai/google/chat/stream_spec.rb
@@ -278,6 +278,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                 ],
               },
               "finishReason" => "STOP",
+              "index" => 0,
             },
           ],
         })
@@ -325,6 +326,7 @@ RSpec.describe OmniAI::Google::Chat::Stream do
                 ],
               },
               "index" => 0,
+              "finishReason" => "STOP",
             },
           ],
         })
@@ -333,6 +335,50 @@ RSpec.describe OmniAI::Google::Chat::Stream do
       it "yields only for chunks with parts" do
         stream!
         expect(deltas.map(&:text)).to eql(["Hello"])
+      end
+    end
+
+    context "when finishReason arrives on a terminal chunk with no content (the real Gemini ordering)" do
+      let(:chunks) do
+        [
+          {
+            candidates: [
+              { content: { role: "model", parts: [{ text: "Hello" }] }, index: 0 },
+            ],
+          },
+          {
+            candidates: [
+              { content: { role: "model", parts: [{ text: " World" }] }, index: 0 },
+            ],
+          },
+          {
+            candidates: [
+              { finishReason: "MAX_TOKENS", index: 0 },
+            ],
+          },
+        ].map { |chunk| "data: #{JSON.generate(chunk)}\n\n" }
+      end
+
+      it "preserves finishReason on the assembled candidate" do
+        expect(stream!).to eql({
+          "candidates" => [
+            {
+              "content" => {
+                "role" => "model",
+                "parts" => [
+                  { "text" => "Hello World" },
+                ],
+              },
+              "index" => 0,
+              "finishReason" => "MAX_TOKENS",
+            },
+          ],
+        })
+      end
+
+      it "yields each text chunk" do
+        stream!
+        expect(deltas.map(&:text)).to eql(["Hello", " World"])
       end
     end
 

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -24,11 +24,13 @@ RSpec.describe OmniAI::Google::Chat do
                 role: "assistant",
                 parts: [{ text: "Two elephants fall off a cliff. Boom! Boom!" }],
               },
+              finishReason: "STOP",
             }],
           })
       end
 
       it { expect(completion.text).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+      it { expect(completion.finish_reason.reason).to eq(:stop) }
     end
 
     context "with an array prompt" do
@@ -109,10 +111,12 @@ RSpec.describe OmniAI::Google::Chat do
             data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'Hello' }], role: 'model' }, index: 0 }])}\n
             data: #{JSON.generate(candidates: [{ content: { parts: [{ text: ' ' }], role: 'model' }, index: 0 }])}\n
             data: #{JSON.generate(candidates: [{ content: { parts: [{ text: 'World' }], role: 'model' }, index: 0 }])}\n
+            data: #{JSON.generate(candidates: [{ finishReason: 'STOP', index: 0 }])}\n
           STREAM
       end
 
       it { expect(completion.text).to eql("Hello World") }
+      it { expect(completion.finish_reason.reason).to eq(:stop) }
     end
 
     context "when formatting as JSON" do

--- a/spec/omniai/google/client_spec.rb
+++ b/spec/omniai/google/client_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe OmniAI::Google::Client do
   describe "#connection" do
     context "without options" do
       it "returns an HTTP client" do
-        expect(client.connection).to be_a(HTTP::Client)
+        expect(client.connection).to respond_to(:request)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe OmniAI::Google::Client do
       it "returns an HTTP client" do
         allow(credentials).to receive(:fetch_access_token!)
         allow(credentials).to receive(:access_token) { SecureRandom.alphanumeric }
-        expect(client.connection).to be_a(HTTP::Client)
+        expect(client.connection).to respond_to(:request)
         expect(credentials).to have_received(:fetch_access_token!)
         expect(credentials).to have_received(:access_token)
       end

--- a/spec/omniai/google/transcribe_helpers_spec.rb
+++ b/spec/omniai/google/transcribe_helpers_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe OmniAI::Google::TranscribeHelpers do
     context "with no timeout configured" do
       let(:client) { OmniAI::Google::Client.new(api_key: "fake", project_id: "test-project") }
 
-      it "wraps nil per-operation (preserving prior behavior)" do
-        expect(transcribe.send(:http_timeout_options)).to eq(connect: nil, write: nil, read: nil)
+      it "returns :null (the http no-timeout sentinel; http 6 rejects nil per-operation values)" do
+        expect(transcribe.send(:http_timeout_options)).to eq(:null)
       end
     end
   end


### PR DESCRIPTION
## Summary

Maps the Gemini candidate `finishReason` onto a normalized `OmniAI::Chat::FinishReason` value object on `Response#finish_reason` (and per-choice) — **and fixes a real, pre-existing streaming bug that silently dropped it.**

## Mapping (table lives next to the deserializer)

| raw `finishReason` | `reason` |
|---|---|
| `STOP` | `:stop` |
| `MAX_TOKENS` | `:length` |
| `SAFETY`, `RECITATION`, `LANGUAGE`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY` | `:filter` |
| `OTHER`, `MALFORMED_FUNCTION_CALL`, anything unrecognized | `:other` |

The whole content-policy family maps to `:filter` (so a consumer branching on `:filter` catches every policy termination), while the **verbatim** token is preserved as `finish_reason.value` — so `RECITATION` vs `SAFETY` granularity is never lost. Values verified against the [FinishReason enum](https://ai.google.dev/api/generate-content#FinishReason).

## Streaming fix — a REAL pre-existing bug (independent of this feature)

In real Gemini streams, `finishReason` arrives on the **terminal chunk, after** content has streamed. But `Stream#merge_candidate!` only merged `content.parts` into an already-seen candidate and **dropped top-level keys**, and `process_candidate!` skipped candidates with no `content` entirely. Net effect: on a streamed `MAX_TOKENS` / `SAFETY` cutoff, `finishReason` was **silently lost** — the exact failures a blank-completion detector exists to catch. (Two pre-existing specs even encoded the dropped behavior as "correct.")

Verified merge semantics after the fix:
- **terminal-chunk top-level keys win** — `finishReason` arriving on a later chunk is merged onto the existing candidate (not discarded);
- **`dig`-guarded part iteration** — no spurious deltas yielded for content-less chunks;
- **`merge_part!` tolerates a content-less first chunk** — `content`/`parts` are initialized on demand, so any chunk ordering assembles correctly.

Two pre-existing specs corrected to the preserving behavior, plus a new regression spec for the realistic ordering (content → terminal `finishReason`-only chunk).

## Tests

TDD; non-streaming + streaming + regression + a mapping-table spec (reason + verbatim-value preservation). `284 examples, 0 failures`; rubocop clean.

## Dependency / release ordering

Bumps the `omniai` floor to `~> 3.7`; releases as **omniai-google 3.10.0**.

⚠️ **Depends on omniai 3.7.0** (ksylvest/omniai#289). Merge + publish that first; CI here goes green once 3.7.0 is on RubyGems.
