### PR TITLE
Add Gemini Flash 3.6 + 3.7; float GEMINI_FLASH to 3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.10.0)
+    omniai-google (3.11.0)
       event_stream_parser
       google-cloud-storage
       googleauth

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ completion.text # 'The capital of Canada is Ottawa.'
 
 #### Model
 
-`model` takes an optional string (default is `gemini-3.5-flash`):
+`model` takes an optional string (default is `gemini-3.7-flash`):
 
 ```ruby
 completion = client.chat('How fast is a cheetah?', model: OmniAI::Google::Chat::Model::GEMINI_FLASH)

--- a/lib/omniai/google/chat.rb
+++ b/lib/omniai/google/chat.rb
@@ -23,11 +23,13 @@ module OmniAI
         GEMINI_2_5_FLASH = "gemini-2.5-flash"
         GEMINI_3_FLASH = "gemini-3-flash-preview"
         GEMINI_3_5_FLASH = "gemini-3.5-flash"
+        GEMINI_3_6_FLASH = "gemini-3.6-flash"
+        GEMINI_3_7_FLASH = "gemini-3.7-flash"
         GEMINI_PRO = GEMINI_3_1_PRO
-        GEMINI_FLASH = GEMINI_3_5_FLASH
+        GEMINI_FLASH = GEMINI_3_7_FLASH
       end
 
-      DEFAULT_MODEL = Model::GEMINI_3_5_FLASH
+      DEFAULT_MODEL = Model::GEMINI_FLASH
 
       module ResponseMimeType
         JSON = "application/json"

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.10.0"
+    VERSION = "3.11.0"
   end
 end

--- a/spec/omniai/google/chat_spec.rb
+++ b/spec/omniai/google/chat_spec.rb
@@ -3,6 +3,16 @@
 RSpec.describe OmniAI::Google::Chat do
   let(:client) { OmniAI::Google::Client.new }
 
+  describe "DEFAULT_MODEL" do
+    it "is gemini-3.7-flash" do
+      expect(described_class::DEFAULT_MODEL).to eq("gemini-3.7-flash")
+    end
+
+    it "tracks the GEMINI_FLASH alias" do
+      expect(described_class::DEFAULT_MODEL).to eq(described_class::Model::GEMINI_FLASH)
+    end
+  end
+
   describe ".process!" do
     subject(:completion) { described_class.process!(prompt, client:, model:) }
 


### PR DESCRIPTION
## Summary

Adds the two GA Flash models that landed upstream since `gemini-3.5-flash`, and floats the generic alias to the newest.

- `GEMINI_3_6_FLASH` = `"gemini-3.6-flash"`
- `GEMINI_3_7_FLASH` = `"gemini-3.7-flash"` — currently the newest GA Flash model; Google's docs now describe 3.6 as previous-generation.

## Behavior change

`GEMINI_FLASH` now points at `GEMINI_3_7_FLASH` (was `GEMINI_3_5_FLASH`). Since `DEFAULT_MODEL` follows that alias, **the provider default moves from `gemini-3.5-flash` to `gemini-3.7-flash`.** Callers who want the old behavior should pin `GEMINI_3_5_FLASH` explicitly.

This mirrors what `omniai-anthropic` 3.4.0 did when floating `CLAUDE_SONNET` to Sonnet 5.

`DEFAULT_MODEL` is also redefined as `Model::GEMINI_FLASH` instead of naming a version directly, matching `omniai-anthropic` (`DEFAULT_MODEL = Model::CLAUDE_SONNET`). Behaviorally identical, but future alias floats now touch one line instead of two that can silently disagree.

## Version

3.10.0 → **3.11.0** (minor, because the default model changes).

## Testing

- `bundle exec rspec` — 284 examples, 0 failures
- `bundle exec rubocop lib` — 25 files, no offenses

⚠️ **Not verified against the live API.** The specs are WebMock-stubbed, so the new model ID strings are never actually sent — a typo would pass. Both IDs were taken from Google's current model docs, but a real request has not been made.