### PR TITLE
Include thinking tokens in output_tokens on Gemini thinking models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 3.12.0
+
+### Changed
+
+- **`OmniAI::Chat::Usage#output_tokens` now includes thinking tokens on Gemini thinking models.** Gemini reports the answer as `candidatesTokenCount` and internal reasoning separately as `thoughtsTokenCount`, and bills both as output. This gem previously read `candidatesTokenCount` alone, so `output_tokens` excluded reasoning and understated billable output — substantially, since thinking is on by default on Gemini 3.x flash models. `output_tokens` is now `candidatesTokenCount + thoughtsTokenCount`, matching Anthropic and OpenAI, where reasoning is already counted in the output total and reported back only as a breakdown.
+
+  **If you were adding `thoughtsTokenCount` yourself to compensate, remove it** — otherwise reasoning is counted twice. There is no error to catch: the number is simply wrong.
+
+  The reasoning subset is available as `Usage#thinking_tokens`, and the raw `thoughtsTokenCount` remains reachable verbatim on `response.data`. Requires omniai >= 3.8.
+
+  This also restores an invariant the gem previously broke: `totalTokenCount` always included thinking, so `input_tokens + output_tokens` did not equal `total_tokens` on any thinking response. It now does.
+
+### Fixed
+
+- `OmniAI::Chat::Usage#serialize` emits `thoughtsTokenCount` and splits inclusive `output_tokens` back into `candidatesTokenCount`, so a usage payload round-trips. It previously wrote `output_tokens` into `candidatesTokenCount` and dropped the reasoning count entirely, making serialization lossy in both directions. The key is omitted when no reasoning is reported, matching Gemini, so payloads for non-thinking responses are unchanged.
+
+Earlier changes are recorded in the GitHub releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
   The reasoning subset is available as `Usage#thinking_tokens`, and the raw `thoughtsTokenCount` remains reachable verbatim on `response.data`. Requires omniai >= 3.8.
 
-  This also restores an invariant the gem previously broke: `totalTokenCount` always included thinking, so `input_tokens + output_tokens` did not equal `total_tokens` on any thinking response. It now does.
+  This also restores an invariant the gem previously broke. On responses whose `usageMetadata` reports only `promptTokenCount`, `candidatesTokenCount` and `thoughtsTokenCount`, `totalTokenCount` is the sum of the three — so `input_tokens + output_tokens` now equals `total_tokens`, where before it could not. Verified live against Vertex on both the streaming and non-streaming paths. Note the scope: `totalTokenCount` also carries buckets this serializer does not read, such as `toolUsePromptTokenCount` on tool-use responses, and the invariant is not claimed for those.
+
+- `UsageSerializer.deserialize` returns `nil` when the payload carries no token counts at all, so `response.usage` can now be `nil` where it previously was a `Usage` with every field `nil`. Gemini sends a `usageMetadata` on every streamed chunk carrying only `trafficType` and populates the counts solely on the terminal chunk, so a stream that ends early assembles a payload whose key is present but whose counts never arrived. Presence of the key is not presence of usage.
+
+  This does not introduce a new class of `nil`: `response.usage` is already `nil` whenever `usageMetadata` is absent entirely, so consumers that work today already nil-check. It makes an existing `nil` more frequent — and for a billing number a loud `nil` is better than an all-`nil` `Usage` that arithmetic silently turns into zero. The test is strictly "no count present", never "counts are falsy"; a reported `0` is a count and still builds a `Usage`.
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.11.0)
+    omniai-google (3.12.0)
       event_stream_parser
       google-cloud-storage
       googleauth
-      omniai (~> 3.7)
+      omniai (~> 3.8)
       openssl
       zeitwerk
 
@@ -97,7 +97,7 @@ GEM
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    omniai (3.7.1)
+    omniai (3.8.0)
       base64
       event_stream_parser
       http (>= 5, < 7)

--- a/lib/omniai/google/chat/usage_serializer.rb
+++ b/lib/omniai/google/chat/usage_serializer.rb
@@ -5,23 +5,39 @@ module OmniAI
     class Chat
       # Overrides usage serialize / deserialize.
       module UsageSerializer
+        # Gemini reports thinking separately from the answer: `candidatesTokenCount` covers the answer only, while
+        # `thoughtsTokenCount` covers internal reasoning. Google bills both as output and `totalTokenCount` includes
+        # both, so `output_tokens` is the sum — matching Anthropic and OpenAI, where reasoning is already folded into
+        # the output count and reported back only as a breakdown.
+        #
         # @param usage [OmniAI::Chat::Usage]
         # @return [Hash]
         def self.serialize(usage, *)
-          {
+          thinking_tokens = usage.thinking_tokens
+          candidates_tokens = usage.output_tokens
+          candidates_tokens -= thinking_tokens if candidates_tokens && thinking_tokens
+
+          data = {
             promptTokenCount: usage.input_tokens,
-            candidatesTokenCount: usage.output_tokens,
+            candidatesTokenCount: candidates_tokens,
             totalTokenCount: usage.total_tokens,
           }
+          # Gemini omits the key entirely when nothing was thought; only emit it when there is a value to report.
+          data[:thoughtsTokenCount] = thinking_tokens unless thinking_tokens.nil?
+          data
         end
 
         # @param data [Hash]
         # @return [OmniAI::Chat::Usage]
         def self.deserialize(data, *)
           input_tokens = data["promptTokenCount"]
-          output_tokens = data["candidatesTokenCount"]
+          candidates_tokens = data["candidatesTokenCount"]
+          thinking_tokens = data["thoughtsTokenCount"]
           total_tokens = data["totalTokenCount"]
-          OmniAI::Chat::Usage.new(input_tokens:, output_tokens:, total_tokens:)
+
+          output_tokens = (candidates_tokens || 0) + (thinking_tokens || 0) if candidates_tokens || thinking_tokens
+
+          OmniAI::Chat::Usage.new(input_tokens:, output_tokens:, total_tokens:, thinking_tokens:)
         end
       end
     end

--- a/lib/omniai/google/chat/usage_serializer.rb
+++ b/lib/omniai/google/chat/usage_serializer.rb
@@ -15,7 +15,10 @@ module OmniAI
         def self.serialize(usage, *)
           thinking_tokens = usage.thinking_tokens
           candidates_tokens = usage.output_tokens
-          candidates_tokens -= thinking_tokens if candidates_tokens && thinking_tokens
+          # `thinking_tokens` is a subset of `output_tokens`, so this cannot go negative for any Usage this gem
+          # builds. Clamp anyway: a hand-constructed Usage that violates the subset invariant should not produce a
+          # negative token count on the wire.
+          candidates_tokens = [candidates_tokens - thinking_tokens, 0].max if candidates_tokens && thinking_tokens
 
           data = {
             promptTokenCount: usage.input_tokens,
@@ -27,13 +30,22 @@ module OmniAI
           data
         end
 
+        # Returns `nil` when the payload carries no token counts at all. A truncated stream still assembles a
+        # `usageMetadata` — Gemini sends one on every chunk, carrying only `trafficType` until the terminal chunk —
+        # so the presence of the key is not the presence of usage. Building a Usage from it would report every
+        # count as `nil`, which arithmetic downstream silently turns into zero.
+        #
+        # The test is strictly "no count is present", never "the counts are falsy": a reported `0` is a count.
+        #
         # @param data [Hash]
-        # @return [OmniAI::Chat::Usage]
+        # @return [OmniAI::Chat::Usage, nil]
         def self.deserialize(data, *)
           input_tokens = data["promptTokenCount"]
           candidates_tokens = data["candidatesTokenCount"]
           thinking_tokens = data["thoughtsTokenCount"]
           total_tokens = data["totalTokenCount"]
+
+          return if [input_tokens, candidates_tokens, thinking_tokens, total_tokens].all?(&:nil?)
 
           output_tokens = (candidates_tokens || 0) + (thinking_tokens || 0) if candidates_tokens || thinking_tokens
 

--- a/lib/omniai/google/embed.rb
+++ b/lib/omniai/google/embed.rb
@@ -40,6 +40,13 @@ module OmniAI
         [data["embedding"]["values"]]
       end
 
+      # Always returns a Usage, never nil — callers rely on `response.usage` being present here without a nil check.
+      #
+      # This deliberately differs from the chat-side `UsageSerializer`, which returns nil when the payload carries
+      # no token counts at all (a truncated Gemini stream still sends a `usageMetadata` containing only
+      # `trafficType`). Embeddings have no streaming path and so no equivalent partial payload, so there is nothing
+      # to distinguish. Do not make this nil-safe "for consistency" with chat: it would turn an unguarded
+      # `response.usage.total_tokens` in a consumer into a NoMethodError.
       USAGE_METADATA_DESERIALIZER = proc do |data, *|
         prompt_tokens = data.dig("usageMetadata", "promptTokenCount")
         total_tokens = data.dig("usageMetadata", "totalTokenCount")

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.11.0"
+    VERSION = "3.12.0"
   end
 end

--- a/omniai-google.gemspec
+++ b/omniai-google.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "event_stream_parser"
   spec.add_dependency "googleauth"
   spec.add_dependency "google-cloud-storage"
-  spec.add_dependency "omniai", "~> 3.7"
+  spec.add_dependency "omniai", "~> 3.8"
   spec.add_dependency "openssl"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/google/chat/usage_serializer_spec.rb
+++ b/spec/omniai/google/chat/usage_serializer_spec.rb
@@ -6,25 +6,111 @@ RSpec.describe OmniAI::Google::Chat::UsageSerializer do
   describe ".deserialize" do
     subject(:deserialize) { described_class.deserialize(data, context:) }
 
-    let(:data) do
-      {
-        "promptTokenCount" => 2,
-        "candidatesTokenCount" => 3,
-        "totalTokenCount" => 5,
-      }
+    context "without thinking" do
+      let(:data) do
+        {
+          "promptTokenCount" => 2,
+          "candidatesTokenCount" => 3,
+          "totalTokenCount" => 5,
+        }
+      end
+
+      it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
+      it { expect(deserialize.input_tokens).to be(2) }
+      it { expect(deserialize.output_tokens).to be(3) }
+      it { expect(deserialize.total_tokens).to be(5) }
+
+      it "leaves thinking_tokens nil rather than reporting zero" do
+        expect(deserialize.thinking_tokens).to be_nil
+      end
     end
 
-    it { expect(deserialize).to be_a(OmniAI::Chat::Usage) }
-    it { expect(deserialize.input_tokens).to be(2) }
-    it { expect(deserialize.output_tokens).to be(3) }
-    it { expect(deserialize.total_tokens).to be(5) }
+    context "with thinking" do
+      # Captured from a live Vertex `generateContent` call: gemini-2.5-flash, us-central1, thinkingBudget 1024.
+      let(:data) do
+        {
+          "promptTokenCount" => 53,
+          "candidatesTokenCount" => 550,
+          "thoughtsTokenCount" => 806,
+          "totalTokenCount" => 1409,
+          "trafficType" => "ON_DEMAND",
+        }
+      end
+
+      it "reports billable output as candidates + thoughts" do
+        expect(deserialize.output_tokens).to be(1356)
+      end
+
+      it "exposes the reasoning breakdown" do
+        expect(deserialize.thinking_tokens).to be(806)
+      end
+
+      it "keeps thinking_tokens a subset of output_tokens" do
+        expect(deserialize.thinking_tokens).to be <= deserialize.output_tokens
+      end
+
+      it "satisfies input + output == total, which candidates-only output did not" do
+        expect(deserialize.input_tokens + deserialize.output_tokens).to eq(deserialize.total_tokens)
+      end
+    end
+
+    context "with a thinking model that reported no thoughts" do
+      let(:data) do
+        {
+          "promptTokenCount" => 2,
+          "candidatesTokenCount" => 3,
+          "thoughtsTokenCount" => 0,
+          "totalTokenCount" => 5,
+        }
+      end
+
+      it "distinguishes a reported zero from an absent breakdown" do
+        expect(deserialize.thinking_tokens).to be(0)
+      end
+
+      it { expect(deserialize.output_tokens).to be(3) }
+    end
+
+    context "without any token counts" do
+      # A truncated stream assembles a usageMetadata carrying only `trafficType`.
+      let(:data) { { "trafficType" => "ON_DEMAND" } }
+
+      it "reports no output rather than zero output" do
+        expect(deserialize.output_tokens).to be_nil
+      end
+    end
   end
 
   describe ".serialize" do
     subject(:serialize) { described_class.serialize(usage, context:) }
 
-    let(:usage) { OmniAI::Chat::Usage.new(input_tokens: 2, output_tokens: 3, total_tokens: 5) }
+    context "without thinking" do
+      let(:usage) { OmniAI::Chat::Usage.new(input_tokens: 2, output_tokens: 3, total_tokens: 5) }
 
-    it { expect(serialize).to eql(promptTokenCount: 2, candidatesTokenCount: 3, totalTokenCount: 5) }
+      it "omits thoughtsTokenCount entirely, as Gemini does" do
+        expect(serialize).to eql(promptTokenCount: 2, candidatesTokenCount: 3, totalTokenCount: 5)
+      end
+    end
+
+    context "with thinking" do
+      let(:usage) do
+        OmniAI::Chat::Usage.new(input_tokens: 53, output_tokens: 1356, total_tokens: 1409, thinking_tokens: 806)
+      end
+
+      it "splits inclusive output back into candidates and thoughts" do
+        expect(serialize).to eql(
+          promptTokenCount: 53,
+          candidatesTokenCount: 550,
+          totalTokenCount: 1409,
+          thoughtsTokenCount: 806
+        )
+      end
+
+      it "round-trips" do
+        usage = described_class.deserialize(serialize.transform_keys(&:to_s), context:)
+        expect(usage.output_tokens).to be(1356)
+        expect(usage.thinking_tokens).to be(806)
+      end
+    end
   end
 end

--- a/spec/omniai/google/chat/usage_serializer_spec.rb
+++ b/spec/omniai/google/chat/usage_serializer_spec.rb
@@ -72,12 +72,23 @@ RSpec.describe OmniAI::Google::Chat::UsageSerializer do
     end
 
     context "without any token counts" do
-      # A truncated stream assembles a usageMetadata carrying only `trafficType`.
+      # Gemini sends a usageMetadata on every chunk carrying only `trafficType`, and populates the counts solely on
+      # the terminal chunk. A stream that dies before that chunk assembles this.
       let(:data) { { "trafficType" => "ON_DEMAND" } }
 
-      it "reports no output rather than zero output" do
-        expect(deserialize.output_tokens).to be_nil
+      it "reports no usage at all, rather than a Usage whose every field is nil" do
+        expect(deserialize).to be_nil
       end
+    end
+
+    context "with a single reported count of zero" do
+      let(:data) { { "candidatesTokenCount" => 0, "trafficType" => "ON_DEMAND" } }
+
+      it "builds a Usage, because a reported zero is a count" do
+        expect(deserialize).to be_a(OmniAI::Chat::Usage)
+      end
+
+      it { expect(deserialize.output_tokens).to be(0) }
     end
   end
 


### PR DESCRIPTION
## The bug

Gemini reports the answer as `candidatesTokenCount` and internal reasoning separately as `thoughtsTokenCount`, and **bills both as output**. `UsageSerializer` read `candidatesTokenCount` alone, so `Usage#output_tokens` was not billable output — it excluded reasoning entirely.

Thinking is on by default on Gemini 3.x flash models, so this is the **default path**, not an edge case. Any consumer computing cost from `output_tokens` has been under-reporting Gemini spend.

### Measured, live against Vertex (`gemini-2.5-flash`, `us-central1`)

Four separate calls across the work; each row is a distinct call, so the numbers differ between them:

| call | raw `usageMetadata` | `output_tokens` before | after |
|---|---|---|---|
| non-streaming | `candidates=584 thoughts=840 total=1475` | 584 | 1424 |
| streaming | `candidates=531 thoughts=760 total=1342` | 531 | 1291 |
| non-streaming | `candidates=660 thoughts=911 total=1622` | 660 | 1571 |
| streaming | `candidates=506 thoughts=932 total=1489` | 506 | 1438 |

**58–65% of billable output was missing.** The spec fixture uses a fifth capture (`53 / 550 / 806 / 1409`), annotated inline with model and region.

Caveat that travels with these numbers: one model, one region. Direction and magnitude are solid; the exact ratio is task- and model-dependent and should not be assumed to transfer to other Gemini generations.

### It also broke an invariant the payload itself satisfies

On responses reporting only `promptTokenCount`, `candidatesTokenCount` and `thoughtsTokenCount`, `totalTokenCount` is the sum of the three — so `input + output` did not equal `total`. `51 + 660 ≠ 1622`. It now does: `51 + 1571 == 1622`.

Scope stated precisely, in code and changelog: `totalTokenCount` also carries buckets this serializer does not read, such as `toolUsePromptTokenCount` on tool-use responses. The invariant is not claimed for those.

## What changed

- `output_tokens` is `candidatesTokenCount + thoughtsTokenCount`, matching Anthropic and OpenAI, where reasoning is already counted in output and reported back only as a breakdown.
- `thinking_tokens` exposes the reasoning subset. Raw `thoughtsTokenCount` remains reachable verbatim on `response.data` — the abstraction is normalized, the provider value is never destroyed.
- `serialize` splits inclusive output back into `candidatesTokenCount` and emits `thoughtsTokenCount`, so payloads round-trip; it previously wrote `output_tokens` into `candidatesTokenCount` and dropped reasoning entirely. The key is omitted when nothing was thought, matching Gemini, so non-thinking payloads are byte-identical. `candidatesTokenCount` is clamped at zero so a hand-constructed `Usage` violating the subset invariant cannot emit a negative count.
- **`deserialize` returns `nil` when the payload carries no token counts at all.** Gemini sends a `usageMetadata` on *every* streamed chunk carrying only `trafficType`, and populates the counts solely on the terminal chunk — confirmed by capturing the raw chunk sequence against live Vertex. A stream ending before that chunk assembled a payload whose key was present but whose counts never arrived, and the serializer built a `Usage` reporting every count as `nil`, which arithmetic downstream silently turns into zero.

  The test is strictly "no count present", never "counts are falsy" — a reported `0` is a count and still builds a `Usage`. This is not a new class of `nil`: `response.usage` is already `nil` when `usageMetadata` is absent entirely, so consumers that work today already nil-check. For a billing number, a loud `nil` beats a silent all-`nil` `Usage`.

## ⚠️ Migration — silent double-count risk

**If you were adding `thoughtsTokenCount` yourself to compensate, remove it.** Otherwise reasoning is counted twice. There is no error to catch; the number is simply wrong. Called out at the top of the CHANGELOG's `Changed` section because reading it is the only way to find out.

## Compatibility

Requires **omniai >= 3.8** (ksylvest/omniai#305); the floor moves `~> 3.7` → `~> 3.8`.

That bump is load-bearing. `~> 3.7` resolves 3.7.1, making `omniai-google 3.12.0 + omniai 3.7.1` an installable combination that raises `ArgumentError: unknown keyword: :thinking_tokens` the first time the serializer runs — reproduced locally before applying the bump. `~> 3.8` converts that production crash into a bundler resolution failure.

**omniai 3.8.0 must be published before this can pass CI.**

## Verification

298 examples, 0 failures (was 286). RuboCop clean. Live assertions pass on both streaming and non-streaming: `output == candidates + thoughts`, `thinking_tokens == thoughtsTokenCount`, `thinking <= output`, `input + output == total`, and raw `thoughtsTokenCount` still reachable on `response.data`.

Four-gem release: [omniai#305](https://github.com/ksylvest/omniai/pull/305) · this · [omniai-anthropic#209](https://github.com/ksylvest/omniai-anthropic/pull/209) · [omniai-openai#217](https://github.com/ksylvest/omniai-openai/pull/217)
