### PR TITLE
Derive the API version from the client's host for Vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.13.0
+
+### Fixed
+
+- A client constructed with Vertex arguments now resolves the correct API version. `Client#initialize` defaulted `version:` to `OmniAI::Google.config.version`, which derives from the *config's* host rather than the client's, so a Vertex client built from constructor arguments inherited `v1beta` and produced `/v1beta/projects/.../locations/...` — a path that 404s against every regional Vertex endpoint. Callers had to pass `version: "v1"` explicitly for constructor-configured Vertex to work at all.
+
+  Only the Vertex case is derived from the client's own host, via the existing `vertex?` predicate. Any other custom host — a proxy or gateway in front of the Gemini API — continues to defer to the configured version, so those callers are not silently moved off the version they were using. An explicit `version:` still wins in all cases.
+
+  Note for anyone hitting the same 404: the regional host must also match the region in the path (`https://us-central1-aiplatform.googleapis.com` with `locations/us-central1`). That is deliberately not derived, because `locations/global` against the global host is a valid combination.
+
 ## 3.12.0
 
 ### Changed

--- a/lib/omniai/google/client.rb
+++ b/lib/omniai/google/client.rb
@@ -39,7 +39,7 @@ module OmniAI
         credentials: OmniAI::Google.config.credentials,
         logger: OmniAI::Google.config.logger,
         host: OmniAI::Google.config.host,
-        version: OmniAI::Google.config.version,
+        version: nil,
         timeout: OmniAI::Google.config.timeout
       )
         if api_key.nil? && credentials.nil?
@@ -51,7 +51,7 @@ module OmniAI
         @project_id = project_id
         @location_id = location_id
         @credentials = Credentials.parse(credentials)
-        @version = version
+        @version = version || default_version
       end
 
       # @raise [OmniAI::Error]
@@ -127,6 +127,19 @@ module OmniAI
       end
 
     private
+
+      # Vertex AI serves `v1`; the Gemini API serves `v1beta`. `OmniAI::Google.config.version` derives from the
+      # *config's* host, not this client's, so a client constructed with a Vertex host but an otherwise default
+      # config inherited `v1beta` and produced `/v1beta/projects/.../locations/...`, which 404s against every
+      # regional endpoint.
+      #
+      # Only the Vertex case is derived from this client's host. Any other custom host — a proxy or gateway in
+      # front of the Gemini API — keeps deferring to the config, so those callers are unaffected.
+      #
+      # @return [String]
+      def default_version
+        vertex? ? Config::Version::STABLE : OmniAI::Google.config.version
+      end
 
       # @return [String] e.g. "Bearer ..."
       def auth

--- a/lib/omniai/google/version.rb
+++ b/lib/omniai/google/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Google
-    VERSION = "3.12.0"
+    VERSION = "3.13.0"
   end
 end

--- a/spec/omniai/google/client_spec.rb
+++ b/spec/omniai/google/client_spec.rb
@@ -47,6 +47,53 @@ RSpec.describe OmniAI::Google::Client do
     end
   end
 
+  describe "#version" do
+    context "with the default Gemini API host" do
+      it "is the beta version" do
+        expect(described_class.new(api_key: "fake").version).to eq(OmniAI::Google::Config::Version::BETA)
+      end
+    end
+
+    context "with a Vertex host" do
+      # `OmniAI::Google.config.version` derives from the config's host, not the client's, so a client built with a
+      # Vertex host used to inherit `v1beta` and 404 against every regional endpoint.
+      it "is the stable version" do
+        client = described_class.new(api_key: "fake", host: "https://us-central1-aiplatform.googleapis.com")
+        expect(client.version).to eq(OmniAI::Google::Config::Version::STABLE)
+      end
+
+      it "builds a v1 path" do
+        client = described_class.new(
+          api_key: "fake",
+          host: "https://us-central1-aiplatform.googleapis.com",
+          project_id: "manhattan",
+          location_id: "us-central1"
+        )
+        expect(client.path).to eq("/v1/projects/manhattan/locations/us-central1/publishers/google")
+      end
+    end
+
+    context "with a custom non-Vertex host" do
+      # A proxy or gateway in front of the Gemini API must keep deferring to the config, so this fix cannot
+      # silently move those callers off the version they were using.
+      it "defers to the configured version" do
+        client = described_class.new(api_key: "fake", host: "https://gateway.example.com")
+        expect(client.version).to eq(OmniAI::Google.config.version)
+      end
+    end
+
+    context "with an explicit version" do
+      it "is respected" do
+        client = described_class.new(
+          api_key: "fake",
+          host: "https://us-central1-aiplatform.googleapis.com",
+          version: "v1beta1"
+        )
+        expect(client.version).to eq("v1beta1")
+      end
+    end
+  end
+
   describe "#connection" do
     context "without options" do
       it "returns an HTTP client" do

--- a/spec/omniai/google/embed_spec.rb
+++ b/spec/omniai/google/embed_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe OmniAI::Google::Embed do
         let(:model) { described_class::Model::GEMINI_EMBEDDING_001 }
 
         before do
-          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:predict")
+          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1/projects/test-project/locations/us-central1/publishers/google/models/#{model}:predict")
             .with(body: {
               instances: [{ content: text }],
             })
@@ -130,7 +130,7 @@ RSpec.describe OmniAI::Google::Embed do
         let(:model) { described_class::Model::GEMINI_EMBEDDING_2_PREVIEW }
 
         before do
-          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
+          stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
             .with(body: {
               content: { parts: [{ text: }] },
             })
@@ -149,7 +149,7 @@ RSpec.describe OmniAI::Google::Embed do
           subject(:process!) { described_class.process!(text, client:, model:, task_type: "RETRIEVAL_QUERY") }
 
           before do
-            stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
+            stub_request(:post, "https://us-central1-aiplatform.googleapis.com//v1/projects/test-project/locations/us-central1/publishers/google/models/#{model}:embedContent")
               .with(body: {
                 content: { parts: [{ text: }] },
                 taskType: "RETRIEVAL_QUERY",


### PR DESCRIPTION
## The bug

`Client#initialize` defaults `version:` to `OmniAI::Google.config.version`, which derives from the **config's** host — not the client's:

```ruby
def version
  @host.eql?(DEFAULT_HOST) ? Version::BETA : Version::STABLE  # Config's @host
end
```

So a client constructed with Vertex arguments but an otherwise default config inherits `v1beta` and builds `/v1beta/projects/.../locations/.../`, which **404s against every regional Vertex endpoint**. Callers have to pass `version: "v1"` explicitly for constructor-configured Vertex to work at all.

Found while running a live Vertex probe: the request 404'd until `version: "v1"` was passed by hand.

## Why the suite didn't catch it

It agreed with the bug. The Vertex embed specs stubbed:

```
https://us-central1-aiplatform.googleapis.com//v1beta/projects/test-project/locations/us-central1/...
```

A Vertex host with a `v1beta` path — the exact broken URL. Those stubs are corrected to `v1` here.

The `#path` specs had a related weakness: they interpolated `client.version` into their own expectations, so they passed no matter what it resolved to.

## The fix

Only the Vertex case derives from the client's own host, via the existing `vertex?` predicate:

```ruby
def default_version
  vertex? ? Config::Version::STABLE : OmniAI::Google.config.version
end
```

**Deliberately narrow.** A blanket "derive from the client's host" would move any custom-host caller — a proxy or gateway in front of the Gemini API — from `v1beta` to `v1`, silently breaking them. Non-Vertex hosts keep deferring to the config. An explicit `version:` still wins in all cases.

## Not fixed here

The regional host must also match the region in the path — `https://us-central1-aiplatform.googleapis.com` with `locations/us-central1`. Passing the global host with a regional path also 404s.

That is **not** derived automatically, because `locations/global` against the global host is a valid combination and deriving would break it. Noted in a code comment for the next person who hits the same 404.

## Release

Cut as **3.13.0** with its own `### Fixed` entry. Standalone rather than folded into [#87](https://github.com/ksylvest/omniai-google/pull/87): endpoint resolution is unrelated to the usage accounting 3.12.0 carries, and #87 is already carrying two changed behaviours.

A 404-fixing behaviour change with no version and no entry would reach users only if it happened to ride along in whatever published next. That is not a release.

**Sequencing:** this branches from `main`, so its `CHANGELOG.md` does not contain 3.12.0's entry (#87 introduces the file). It merges **after** #87 and rebases — the two changelogs then merge by prepending this entry above 3.12.0. That trivial rebase is the deliberate cost of keeping the branches independent rather than stacking them.

Independent of the four-gem `thinking_tokens` release ([omniai#305](https://github.com/ksylvest/omniai/pull/305) and friends) in every other respect.

## Verification

291 examples, 0 failures. RuboCop clean. New `#version` coverage for the default host, a Vertex host, a custom non-Vertex host (the regression guard), and an explicit override.
