### PR TITLE
Update Gemfile.lock for the 3.13.0 version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-google (3.12.0)
+    omniai-google (3.13.0)
       event_stream_parser
       google-cloud-storage
       googleauth


### PR DESCRIPTION
## The failure

`main`'s build fails at dependency install, before any spec runs:

```
The gemspecs for path gems changed, but the lockfile can't be updated
because frozen mode is set
##[error]The process '.../bundle' failed with exit code 16
```

`version.rb` reads **3.13.0**; `Gemfile.lock`'s `PATH` block still records **3.12.0**. CI runs `bundle install` in frozen mode, which will not reconcile a path gem whose gemspec version has moved.

## The fix

One line, no code change:

```diff
 PATH
   remote: .
   specs:
-    omniai-google (3.12.0)
+    omniai-google (3.13.0)
```

## Verification

Reproduced and confirmed rather than assumed:

| | `BUNDLE_FROZEN=true bundle install` |
|---|---|
| lock reverted to 3.12.0 | **exit 16** — reproduces the CI error verbatim |
| lock at 3.13.0 (this PR) | **passes** |

303 examples, 0 failures. RuboCop clean.

## How it got in

The 3.13.0 bump changed `version.rb` and the CHANGELOG but never staged the regenerated lock. Bundler had already corrected the file locally as a side effect of running the suite, so local checks passed against a consistent working tree while the commit carried the mismatch — a green suite was evidence the file had been *fixed*, not that it had been *committed*.

Worth noting frozen mode behaved correctly here: it refused to silently paper over a gemspec/lock skew, and failed loudly and early rather than publishing a gem whose lockfile disagreed with its own version.

## Scope

`omniai-anthropic` (3.6.0) and `omniai-openai` (3.2.0) both committed their lockfiles with their version bumps and are unaffected — checked, not assumed.

Nothing is published: rubygems still serves omniai-google 3.11.0, so neither 3.12.0 nor 3.13.0 shipped in a broken state.